### PR TITLE
Added missing pointer index check

### DIFF
--- a/runtime/src/main/java/org/capnproto/StructBuilder.java
+++ b/runtime/src/main/java/org/capnproto/StructBuilder.java
@@ -167,7 +167,7 @@ public class StructBuilder {
     }
 
     protected final boolean _pointerFieldIsNull(int ptrIndex) {
-        return this.segment.buffer.getLong((this.pointers + ptrIndex) * Constants.BYTES_PER_WORD) == 0;
+        return ptrIndex >= this.pointerCount || this.segment.buffer.getLong((this.pointers + ptrIndex) * Constants.BYTES_PER_WORD) == 0;
     }
 
     protected final void _clearPointerField(int ptrIndex) {

--- a/runtime/src/main/java/org/capnproto/StructReader.java
+++ b/runtime/src/main/java/org/capnproto/StructReader.java
@@ -151,7 +151,7 @@ public class StructReader {
     }
 
     protected final boolean _pointerFieldIsNull(int ptrIndex) {
-        return this.segment.buffer.getLong((this.pointers + ptrIndex) * Constants.BYTES_PER_WORD) == 0;
+        return ptrIndex >= this.pointerCount || this.segment.buffer.getLong((this.pointers + ptrIndex) * Constants.BYTES_PER_WORD) == 0;
     }
 
     protected final <T> T _getPointerField(FromPointerReader<T> factory, int ptrIndex) {


### PR DESCRIPTION
Added pointer index check. This fixes an IndexOutOfBoundsException when checking for existence of later added fields which are only known on the receiver side (working with different schema versions).