### PR TITLE
Introduce external arenas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,11 @@ project/target
 *.iws
 capnpc-java
 generated/
+/nbproject/private/
+/build/
+/dist/
+build.xml
+manifest.mf
+nbproject/*
+**/pom.xml
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,9 @@ install:
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
   - openjdk7
 script:
-  - make
-  - make addressbook
+  - sbt compile
   - sbt test
   - sbt doc
 

--- a/compiler/src/main/cpp/capnpc-java.c++
+++ b/compiler/src/main/cpp/capnpc-java.c++
@@ -1136,7 +1136,7 @@ private:
 
       uint64_t typeId = field.getContainingStruct().getProto().getId();
       kj::String defaultParams = defaultOffset == 0 ? kj::str("null, 0, 0") : kj::str(
-        "Schemas.b_", kj::hex(typeId), ".buffer, ", defaultOffset, ", ", defaultSize);
+        "Schemas.b_", kj::hex(typeId), ".getBuffer(), ", defaultOffset, ", ", defaultSize);
 
       kj::String blobKind =  typeBody.which() == schema::Type::TEXT ? kj::str("Text") : kj::str("Data");
       kj::String setterInputType = typeBody.which() == schema::Type::TEXT ? kj::str("String") : kj::str("byte []");
@@ -1417,7 +1417,7 @@ private:
         spaces(indent), "    }\n",
 
         spaces(indent),
-        "    public final Reader", readerTypeParams, " constructReader(org.capnproto.SegmentReader segment, int data,",
+        "    public final Reader", readerTypeParams, " constructReader(org.capnproto.SegmentDataContainer segment, int data,",
         "int pointers, int dataSize, short pointerCount, int nestingLimit) {\n",
         spaces(indent), "      return new Reader", readerTypeParams, "(",
         KJ_MAP(p, typeParamVec) {
@@ -1425,7 +1425,7 @@ private:
         },
         "segment,data,pointers,dataSize,pointerCount,nestingLimit);\n",
         spaces(indent), "    }\n",
-        spaces(indent), "    public final Builder", builderTypeParams, " constructBuilder(org.capnproto.SegmentBuilder segment, int data,",
+        spaces(indent), "    public final Builder", builderTypeParams, " constructBuilder(org.capnproto.GenericSegmentBuilder segment, int data,",
         "int pointers, int dataSize, short pointerCount) {\n",
         spaces(indent), "      return new Builder", builderTypeParams, "(",
         KJ_MAP(p, typeParamVec) {
@@ -1468,7 +1468,7 @@ private:
           KJ_MAP(p, typeParamVec) {
             return kj::strTree("org.capnproto.PointerFactory<", p, "_Builder, ?> ", p, "_Factory,");
           },
-          "org.capnproto.SegmentBuilder segment, int data, int pointers,",
+          "org.capnproto.GenericSegmentBuilder segment, int data, int pointers,",
           "int dataSize, short pointerCount){\n",
           spaces(indent+1), "    super(segment, data, pointers, dataSize, pointerCount);\n",
           KJ_MAP(p, typeParamVec) {
@@ -1500,7 +1500,7 @@ private:
           KJ_MAP(p, typeParamVec) {
             return kj::strTree("org.capnproto.PointerFactory<?,", p, "_Reader> ", p, "_Factory,");
           },
-          "org.capnproto.SegmentReader segment, int data, int pointers,",
+          "org.capnproto.SegmentDataContainer segment, int data, int pointers,",
           "int dataSize, short pointerCount, int nestingLimit){\n",
           spaces(indent+1), "    super(segment, data, pointers, dataSize, pointerCount, nestingLimit);\n",
           KJ_MAP(p, typeParamVec) {
@@ -1577,7 +1577,7 @@ private:
           kj::strTree(spaces(indent),
                       "public static final org.capnproto.Text.Reader ", upperCase,
                       " = new org.capnproto.Text.Reader(Schemas.b_",
-                      kj::hex(proto.getId()), ".buffer, ", schema.getValueSchemaOffset(),
+                      kj::hex(proto.getId()), ".getBuffer(), ", schema.getValueSchemaOffset(),
                       ", ", constProto.getValue().getText().size(), ");\n")
         };
       }
@@ -1588,7 +1588,7 @@ private:
           kj::strTree(spaces(indent),
                       "public static final org.capnproto.Data.Reader ", upperCase,
                       " = new org.capnproto.Data.Reader(Schemas.b_",
-                      kj::hex(proto.getId()), ".buffer, ", schema.getValueSchemaOffset(),
+                      kj::hex(proto.getId()), ".getBuffer(), ", schema.getValueSchemaOffset(),
                       ", ", constProto.getValue().getData().size(), ");\n")
         };
       }
@@ -1727,7 +1727,7 @@ private:
 
     // Java limits method code size to 64KB. Maybe we should use class.getResource()?
     auto schemaDef = kj::strTree(
-      "public static final org.capnproto.SegmentReader b_", hexId, " =\n",
+      "public static final org.capnproto.SegmentDataContainer b_", hexId, " =\n",
       "   org.capnproto.GeneratedClassSupport.decodeRawBytes(\n",
       "   ", kj::mv(schemaLiteral), " \"\"",
       ");\n");

--- a/runtime/src/main/java/org/capnproto/AllocatedArena.java
+++ b/runtime/src/main/java/org/capnproto/AllocatedArena.java
@@ -20,29 +20,27 @@
 // THE SOFTWARE.
 package org.capnproto;
 
-import java.nio.ByteBuffer;
+import java.util.List;
 
-public class SegmentReader implements GenericSegmentReader {
+/**
+ * Represents an Arena with previously allocated Segments.
+ */
+public interface AllocatedArena extends Arena {
 
-    public final ByteBuffer buffer;
-    private final AllocatedArena arena;
-
-    public SegmentReader(ByteBuffer buffer, AllocatedArena arena) {
-        this.buffer = buffer;
-        this.arena = arena;
-    }
-
-    public long get(int index) {
-        return buffer.getLong(index * Constants.BYTES_PER_WORD);
-    }
-
-    public AllocatedArena getArena() {
-        return arena;
-    }
-
+    /**
+     * Provides the {@link GenericSegmentReader} for the given segment ID.
+     *
+     * @param segmentId the segment ID.
+     * @return the segment.
+     */
     @Override
-    public ByteBuffer getBuffer() {
-        return buffer;
-    }
+    public GenericSegmentReader tryGetSegment(int segmentId);
+
+    /**
+     * Access all existing segments
+     *
+     * @return the segments.
+     */
+    List<GenericSegmentReader> getSegments();
 
 }

--- a/runtime/src/main/java/org/capnproto/AllocatedArena.java
+++ b/runtime/src/main/java/org/capnproto/AllocatedArena.java
@@ -41,6 +41,6 @@ public interface AllocatedArena extends Arena {
      *
      * @return the segments.
      */
-    List<GenericSegmentReader> getSegments();
+    List<? extends GenericSegmentReader> getSegments();
 
 }

--- a/runtime/src/main/java/org/capnproto/AllocatingArena.java
+++ b/runtime/src/main/java/org/capnproto/AllocatingArena.java
@@ -58,5 +58,5 @@ public interface AllocatingArena extends Arena {
      *
      * @return the segments.
      */
-    List<GenericSegmentBuilder> getSegments();
+    List<? extends GenericSegmentBuilder> getSegments();
 }

--- a/runtime/src/main/java/org/capnproto/AllocatingArena.java
+++ b/runtime/src/main/java/org/capnproto/AllocatingArena.java
@@ -1,0 +1,34 @@
+package org.capnproto;
+
+import java.nio.ByteBuffer;
+
+/**
+ * The AllocatingArena defines methods required for the Builder.
+ */
+public interface AllocatingArena extends Arena {
+
+    /**
+     * Allocate a new Segment in case the previous Segment is not big enough for
+     * the requested data.
+     *
+     * @param amountPlusRef the number of words needed.
+     * @return The result of the allocation.
+     */
+    public BuilderArena.AllocateResult allocate(int amountPlusRef);
+
+    /**
+     * Retrieve the SegmentBuilder for given segmentId.
+     *
+     * @param segmentId the given segment ID
+     * @return the segmentBuilder.
+     */
+    public SegmentBuilder getSegment(int segmentId);
+
+    /**
+     * Retrieve the ByteBuffers for Serialization.
+     *
+     * @return the buffers.
+     */
+    public ByteBuffer[] getSegmentsForOutput();
+
+}

--- a/runtime/src/main/java/org/capnproto/AnyPointer.java
+++ b/runtime/src/main/java/org/capnproto/AnyPointer.java
@@ -23,13 +23,13 @@ package org.capnproto;
 
 public final class AnyPointer {
     public static final class Factory implements PointerFactory<Builder, Reader> {
-        public final Reader fromPointerReader(SegmentReader segment, int pointer, int nestingLimit) {
+        public final Reader fromPointerReader(SegmentDataContainer segment, int pointer, int nestingLimit) {
             return new Reader(segment, pointer, nestingLimit);
         }
-        public final Builder fromPointerBuilder(SegmentBuilder segment, int pointer) {
+        public final Builder fromPointerBuilder(GenericSegmentBuilder segment, int pointer) {
             return new Builder(segment, pointer);
         }
-        public final Builder initFromPointerBuilder(SegmentBuilder segment, int pointer, int elementCount) {
+        public final Builder initFromPointerBuilder(GenericSegmentBuilder segment, int pointer, int elementCount) {
             Builder result = new Builder(segment, pointer);
             result.clear();
             return result;
@@ -38,18 +38,18 @@ public final class AnyPointer {
     public static final Factory factory = new Factory();
 
     public final static class Reader {
-        final SegmentReader segment;
+        final SegmentDataContainer segment;
         final int pointer; // offset in words
         final int nestingLimit;
 
-        public Reader(SegmentReader segment, int pointer, int nestingLimit) {
+        public Reader(SegmentDataContainer segment, int pointer, int nestingLimit) {
             this.segment = segment;
             this.pointer = pointer;
             this.nestingLimit = nestingLimit;
         }
 
         public final boolean isNull() {
-            return WirePointer.isNull(this.segment.buffer.getLong(this.pointer * Constants.BYTES_PER_WORD));
+            return WirePointer.isNull(this.segment.getBuffer().getLong(this.pointer * Constants.BYTES_PER_WORD));
         }
 
         public final <T> T getAs(FromPointerReader<T> factory) {
@@ -58,16 +58,16 @@ public final class AnyPointer {
     }
 
     public static final class Builder {
-        final SegmentBuilder segment;
+        final GenericSegmentBuilder segment;
         final int pointer;
 
-        public Builder(SegmentBuilder segment, int pointer) {
+        public Builder(GenericSegmentBuilder segment, int pointer) {
             this.segment = segment;
             this.pointer = pointer;
         }
 
         public final boolean isNull() {
-            return WirePointer.isNull(this.segment.buffer.getLong(this.pointer * Constants.BYTES_PER_WORD));
+            return WirePointer.isNull(this.segment.getBuffer().getLong(this.pointer * Constants.BYTES_PER_WORD));
         }
 
         public final <T> T getAs(FromPointerBuilder<T> factory) {
@@ -92,7 +92,7 @@ public final class AnyPointer {
 
         public final void clear() {
             WireHelpers.zeroObject(this.segment, this.pointer);
-            this.segment.buffer.putLong(this.pointer * 8, 0L);
+            this.segment.getBuffer().putLong(this.pointer * 8, 0L);
         }
     }
 

--- a/runtime/src/main/java/org/capnproto/Arena.java
+++ b/runtime/src/main/java/org/capnproto/Arena.java
@@ -18,10 +18,17 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
 package org.capnproto;
 
 public interface Arena {
-    public SegmentReader tryGetSegment(int id);
+
+    /**
+     * Retrieve the SegmentDataContainer for given segmentId.
+     *
+     * @param segmentId the given segment ID
+     * @return the segmentDataContainer.
+     */
+    public SegmentDataContainer tryGetSegment(int segmentId);
+
     public void checkReadLimit(int numBytes);
 }

--- a/runtime/src/main/java/org/capnproto/ArrayInputStream.java
+++ b/runtime/src/main/java/org/capnproto/ArrayInputStream.java
@@ -36,6 +36,10 @@ public final class ArrayInputStream implements BufferedInputStream {
     public final int read(ByteBuffer dst) throws IOException {
         int available = this.buf.remaining();
         int size = java.lang.Math.min(dst.remaining(), available);
+        if (size == 0) {
+            // end of stream
+            return -1;
+        }
 
         ByteBuffer slice = this.buf.slice();
         slice.limit(size);

--- a/runtime/src/main/java/org/capnproto/ArrayOutputStream.java
+++ b/runtime/src/main/java/org/capnproto/ArrayOutputStream.java
@@ -23,7 +23,6 @@ package org.capnproto;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.WritableByteChannel;
 
 public final class ArrayOutputStream implements BufferedOutputStream {
 

--- a/runtime/src/main/java/org/capnproto/BuilderArena.java
+++ b/runtime/src/main/java/org/capnproto/BuilderArena.java
@@ -25,7 +25,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 
-public final class BuilderArena implements Arena {
+public final class BuilderArena implements AllocatingArena {
 
     public enum AllocationStrategy {
         FIXED_SIZE,

--- a/runtime/src/main/java/org/capnproto/BuilderArena.java
+++ b/runtime/src/main/java/org/capnproto/BuilderArena.java
@@ -18,12 +18,12 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
 package org.capnproto;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
+import java.util.List;
 
 public final class BuilderArena implements AllocatingArena {
 
@@ -33,41 +33,43 @@ public final class BuilderArena implements AllocatingArena {
     }
 
     public static final int SUGGESTED_FIRST_SEGMENT_WORDS = 1024;
-    public static final AllocationStrategy SUGGESTED_ALLOCATION_STRATEGY =
-        AllocationStrategy.GROW_HEURISTICALLY;
+    public static final AllocationStrategy SUGGESTED_ALLOCATION_STRATEGY
+            = AllocationStrategy.GROW_HEURISTICALLY;
 
-    public final ArrayList<SegmentBuilder> segments;
+    public final ArrayList<GenericSegmentBuilder> segments;
 
     public int nextSize;
     public final AllocationStrategy allocationStrategy;
 
-
     public BuilderArena(int firstSegmentSizeWords, AllocationStrategy allocationStrategy) {
-        this.segments = new ArrayList<SegmentBuilder>();
+        this.segments = new ArrayList<GenericSegmentBuilder>();
         this.nextSize = firstSegmentSizeWords;
         this.allocationStrategy = allocationStrategy;
-        SegmentBuilder segment0 = new SegmentBuilder(
-            ByteBuffer.allocate(firstSegmentSizeWords * Constants.BYTES_PER_WORD), this);
-        segment0.buffer.order(ByteOrder.LITTLE_ENDIAN);
+        GenericSegmentBuilder segment0 = new SegmentBuilder(
+                ByteBuffer.allocate(firstSegmentSizeWords * Constants.BYTES_PER_WORD), this);
+        segment0.getBuffer().order(ByteOrder.LITTLE_ENDIAN);
         this.segments.add(segment0);
     }
 
-    public final SegmentReader tryGetSegment(int id) {
-        return this.segments.get(id);
+    public List<GenericSegmentBuilder> getSegments() {
+        return segments;
     }
-    public final SegmentBuilder getSegment(int id) {
+
+    public final GenericSegmentBuilder tryGetSegment(int id) {
         return this.segments.get(id);
     }
 
-    public final void checkReadLimit(int numBytes) { }
+    public final void checkReadLimit(int numBytes) {
+    }
 
     public static class AllocateResult {
-        public final SegmentBuilder segment;
+
+        public final GenericSegmentBuilder segment;
 
         // offset to the beginning the of allocated memory
         public final int offset;
 
-        public AllocateResult(SegmentBuilder segment, int offset) {
+        public AllocateResult(GenericSegmentBuilder segment, int offset) {
             this.segment = segment;
             this.offset = offset;
         }
@@ -79,29 +81,27 @@ public final class BuilderArena implements AllocatingArena {
         // we allocate the first segment in the constructor.
 
         int result = this.segments.get(len - 1).allocate(amount);
-        if (result != SegmentBuilder.FAILED_ALLOCATION) {
+        if (result != GenericSegmentBuilder.FAILED_ALLOCATION) {
             return new AllocateResult(this.segments.get(len - 1), result);
         }
 
         // allocate_owned_memory
-
         int size = Math.max(amount, this.nextSize);
-        SegmentBuilder newSegment = new SegmentBuilder(
-            ByteBuffer.allocate(size * Constants.BYTES_PER_WORD),
-            this);
+        GenericSegmentBuilder newSegment = new SegmentBuilder(
+                ByteBuffer.allocate(size * Constants.BYTES_PER_WORD),
+                this);
 
         switch (this.allocationStrategy) {
-        case GROW_HEURISTICALLY:
-            this.nextSize += size;
-            break;
-        default:
-            break;
+            case GROW_HEURISTICALLY:
+                this.nextSize += size;
+                break;
+            default:
+                break;
         }
 
         // --------
-
-        newSegment.buffer.order(ByteOrder.LITTLE_ENDIAN);
-        newSegment.id = len;
+        newSegment.getBuffer().order(ByteOrder.LITTLE_ENDIAN);
+        newSegment.setId(len);
         this.segments.add(newSegment);
 
         return new AllocateResult(newSegment, newSegment.allocate(amount));
@@ -110,12 +110,8 @@ public final class BuilderArena implements AllocatingArena {
     public final ByteBuffer[] getSegmentsForOutput() {
         ByteBuffer[] result = new ByteBuffer[this.segments.size()];
         for (int ii = 0; ii < this.segments.size(); ++ii) {
-            SegmentBuilder segment = segments.get(ii);
-            segment.buffer.rewind();
-            ByteBuffer slice = segment.buffer.slice();
-            slice.limit(segment.currentSize() * Constants.BYTES_PER_WORD);
-            slice.order(ByteOrder.LITTLE_ENDIAN);
-            result[ii] = slice;
+            GenericSegmentBuilder segment = segments.get(ii);
+            result[ii] = segment.getSegmentForOutput();
         }
         return result;
     }

--- a/runtime/src/main/java/org/capnproto/Data.java
+++ b/runtime/src/main/java/org/capnproto/Data.java
@@ -28,14 +28,14 @@ public final class Data {
                                       PointerFactory<Builder, Reader>,
                                       FromPointerBuilderBlobDefault<Builder>,
                                       SetPointerBuilder<Builder, Reader> {
-        public final Reader fromPointerReaderBlobDefault(SegmentReader segment, int pointer, java.nio.ByteBuffer defaultBuffer,
+        public final Reader fromPointerReaderBlobDefault(SegmentDataContainer segment, int pointer, java.nio.ByteBuffer defaultBuffer,
                                                    int defaultOffset, int defaultSize) {
             return WireHelpers.readDataPointer(segment, pointer, defaultBuffer, defaultOffset, defaultSize);
         }
-        public final Reader fromPointerReader(SegmentReader segment, int pointer, int nestingLimit) {
+        public final Reader fromPointerReader(SegmentDataContainer segment, int pointer, int nestingLimit) {
             return WireHelpers.readDataPointer(segment, pointer, null, 0, 0);
         }
-        public final Builder fromPointerBuilderBlobDefault(SegmentBuilder segment, int pointer,
+        public final Builder fromPointerBuilderBlobDefault(GenericSegmentBuilder segment, int pointer,
                                                      java.nio.ByteBuffer defaultBuffer, int defaultOffset, int defaultSize) {
             return WireHelpers.getWritableDataPointer(pointer,
                                                       segment,
@@ -43,17 +43,17 @@ public final class Data {
                                                       defaultOffset,
                                                       defaultSize);
         }
-        public final Builder fromPointerBuilder(SegmentBuilder segment, int pointer) {
+        public final Builder fromPointerBuilder(GenericSegmentBuilder segment, int pointer) {
             return WireHelpers.getWritableDataPointer(pointer,
                                                       segment,
                                                       null, 0, 0);
         }
 
-        public final Builder initFromPointerBuilder(SegmentBuilder segment, int pointer, int size) {
+        public final Builder initFromPointerBuilder(GenericSegmentBuilder segment, int pointer, int size) {
             return WireHelpers.initDataPointer(pointer, segment, size);
         }
 
-        public final void setPointerBuilder(SegmentBuilder segment, int pointer, Reader value) {
+        public final void setPointerBuilder(GenericSegmentBuilder segment, int pointer, Reader value) {
             WireHelpers.setDataPointer(pointer, segment, value);
         }
     }

--- a/runtime/src/main/java/org/capnproto/DataList.java
+++ b/runtime/src/main/java/org/capnproto/DataList.java
@@ -24,7 +24,7 @@ package org.capnproto;
 public final class DataList {
     public static final class Factory extends ListFactory<Builder, Reader> {
         Factory() {super (ElementSize.POINTER); }
-        public final Reader constructReader(SegmentReader segment,
+        public final Reader constructReader(SegmentDataContainer segment,
                                               int ptr,
                                               int elementCount, int step,
                                               int structDataSize, short structPointerCount,
@@ -32,7 +32,7 @@ public final class DataList {
             return new Reader(segment, ptr, elementCount, step, structDataSize, structPointerCount, nestingLimit);
         }
 
-        public final Builder constructBuilder(SegmentBuilder segment,
+        public final Builder constructBuilder(GenericSegmentBuilder segment,
                                               int ptr,
                                               int elementCount, int step,
                                               int structDataSize, short structPointerCount) {
@@ -42,7 +42,7 @@ public final class DataList {
     public static final Factory factory = new Factory();
 
     public static final class Reader extends ListReader implements Iterable<Data.Reader> {
-        public Reader(SegmentReader segment,
+        public Reader(SegmentDataContainer segment,
                       int ptr,
                       int elementCount, int step,
                       int structDataSize, short structPointerCount,
@@ -79,7 +79,7 @@ public final class DataList {
 
     public static final class Builder extends ListBuilder implements Iterable<Data.Builder> {
 
-        public Builder(SegmentBuilder segment, int ptr,
+        public Builder(GenericSegmentBuilder segment, int ptr,
                        int elementCount, int step,
                        int structDataSize, short structPointerCount){
             super(segment, ptr, elementCount, step, structDataSize, structPointerCount);

--- a/runtime/src/main/java/org/capnproto/EnumList.java
+++ b/runtime/src/main/java/org/capnproto/EnumList.java
@@ -37,7 +37,7 @@ public class EnumList {
             super(ElementSize.TWO_BYTES);
             this.values = values;
         }
-        public final Reader<T> constructReader(SegmentReader segment,
+        public final Reader<T> constructReader(SegmentDataContainer segment,
                                                int ptr,
                                                int elementCount, int step,
                                                int structDataSize, short structPointerCount,
@@ -46,7 +46,7 @@ public class EnumList {
                                  segment, ptr, elementCount, step, structDataSize, structPointerCount, nestingLimit);
         }
 
-        public final Builder<T> constructBuilder(SegmentBuilder segment,
+        public final Builder<T> constructBuilder(GenericSegmentBuilder segment,
                                                  int ptr,
                                                  int elementCount, int step,
                                                  int structDataSize, short structPointerCount) {
@@ -58,7 +58,7 @@ public class EnumList {
         public final T values[];
 
         public Reader(T values[],
-                      SegmentReader segment,
+                      SegmentDataContainer segment,
                       int ptr,
                       int elementCount, int step,
                       int structDataSize, short structPointerCount,
@@ -76,7 +76,7 @@ public class EnumList {
         public final T values[];
 
         public Builder(T values[],
-                       SegmentBuilder segment,
+                       GenericSegmentBuilder segment,
                        int ptr,
                        int elementCount, int step,
                        int structDataSize, short structPointerCount) {

--- a/runtime/src/main/java/org/capnproto/FromPointerBuilder.java
+++ b/runtime/src/main/java/org/capnproto/FromPointerBuilder.java
@@ -22,6 +22,6 @@
 package org.capnproto;
 
 public interface FromPointerBuilder<T> {
-    T fromPointerBuilder(SegmentBuilder segment, int pointer);
-    T initFromPointerBuilder(SegmentBuilder segment, int pointer, int elementCount);
+    T fromPointerBuilder(GenericSegmentBuilder segment, int pointer);
+    T initFromPointerBuilder(GenericSegmentBuilder segment, int pointer, int elementCount);
 }

--- a/runtime/src/main/java/org/capnproto/FromPointerBuilderBlobDefault.java
+++ b/runtime/src/main/java/org/capnproto/FromPointerBuilderBlobDefault.java
@@ -22,6 +22,6 @@
 package org.capnproto;
 
 public interface FromPointerBuilderBlobDefault<T> {
-    T fromPointerBuilderBlobDefault(SegmentBuilder segment, int pointer,
+    T fromPointerBuilderBlobDefault(GenericSegmentBuilder segment, int pointer,
                                     java.nio.ByteBuffer defaultBuffer, int defaultOffset, int defaultSize);
 }

--- a/runtime/src/main/java/org/capnproto/FromPointerBuilderRefDefault.java
+++ b/runtime/src/main/java/org/capnproto/FromPointerBuilderRefDefault.java
@@ -22,5 +22,5 @@
 package org.capnproto;
 
 public interface FromPointerBuilderRefDefault<T> {
-    T fromPointerBuilderRefDefault(SegmentBuilder segment, int pointer, SegmentReader defaultSegment, int defaultOffset);
+    T fromPointerBuilderRefDefault(GenericSegmentBuilder segment, int pointer, SegmentDataContainer defaultSegment, int defaultOffset);
 }

--- a/runtime/src/main/java/org/capnproto/FromPointerReader.java
+++ b/runtime/src/main/java/org/capnproto/FromPointerReader.java
@@ -22,5 +22,5 @@
 package org.capnproto;
 
 public interface FromPointerReader<T> {
-    T fromPointerReader(SegmentReader segment, int pointer, int nestingLimit);
+    T fromPointerReader(SegmentDataContainer segment, int pointer, int nestingLimit);
 }

--- a/runtime/src/main/java/org/capnproto/FromPointerReaderBlobDefault.java
+++ b/runtime/src/main/java/org/capnproto/FromPointerReaderBlobDefault.java
@@ -22,6 +22,6 @@
 package org.capnproto;
 
 public interface FromPointerReaderBlobDefault<T> {
-    T fromPointerReaderBlobDefault(SegmentReader segment, int pointer, java.nio.ByteBuffer defaultBuffer,
+    T fromPointerReaderBlobDefault(SegmentDataContainer segment, int pointer, java.nio.ByteBuffer defaultBuffer,
                                    int defaultOffset, int defaultSize);
 }

--- a/runtime/src/main/java/org/capnproto/FromPointerReaderRefDefault.java
+++ b/runtime/src/main/java/org/capnproto/FromPointerReaderRefDefault.java
@@ -22,5 +22,5 @@
 package org.capnproto;
 
 public interface FromPointerReaderRefDefault<T> {
-    T fromPointerReaderRefDefault(SegmentReader segment, int pointer, SegmentReader defaultSegment, int defaultOffset, int nestingLimit);
+    T fromPointerReaderRefDefault(SegmentDataContainer segment, int pointer, SegmentDataContainer defaultSegment, int defaultOffset, int nestingLimit);
 }

--- a/runtime/src/main/java/org/capnproto/GeneratedClassSupport.java
+++ b/runtime/src/main/java/org/capnproto/GeneratedClassSupport.java
@@ -22,7 +22,7 @@
 package org.capnproto;
 
 public final class GeneratedClassSupport {
-    public static SegmentReader decodeRawBytes(String s) {
+    public static GenericSegmentReader decodeRawBytes(String s) {
         try {
             java.nio.ByteBuffer buffer = java.nio.ByteBuffer.wrap(s.getBytes("ISO_8859-1")).asReadOnlyBuffer();
             buffer.order(java.nio.ByteOrder.LITTLE_ENDIAN);

--- a/runtime/src/main/java/org/capnproto/GenericSegmentBuilder.java
+++ b/runtime/src/main/java/org/capnproto/GenericSegmentBuilder.java
@@ -21,42 +21,72 @@
 package org.capnproto;
 
 import java.nio.ByteBuffer;
-import java.util.List;
 
 /**
- * The Arena used for allocating new Segments.
+ * Representation of the SegmentBuilder. This Builder is responsible to manage
+ * one Segment for building a new Message.
  */
-public interface AllocatingArena extends Arena {
+public interface GenericSegmentBuilder extends SegmentDataContainer {
+
+    static final int FAILED_ALLOCATION = -1;
 
     /**
-     * Allocate a new Segment in case the previous Segment is not big enough for
-     * the requested data.
+     * Puts the long value into the buffer at word index.
      *
-     * @param amountPlusRef the number of words needed.
-     * @return The result of the allocation.
+     * @param index The word index.
+     * @param value The value to add.
      */
-    BuilderArena.AllocateResult allocate(int amountPlusRef);
+    void put(int index, long value);
 
     /**
-     * Provides the {@link GenericSegmentBuilder} for the given segment ID.
+     * The current size of the Segment.
      *
-     * @param segmentId the segment ID
-     * @return the segment.
+     * @return size
      */
-    @Override
-    GenericSegmentBuilder tryGetSegment(int segmentId);
+    int currentSize();
 
     /**
-     * Retrieve the ByteBuffers for Serialization.
+     * allocate more memory in this segment.
      *
-     * @return the buffers.
+     * @param words
+     * @return the start position of the allocated words. -1 means there was not
+     * enough space in the segment.
      */
-    ByteBuffer[] getSegmentsForOutput();
+    int allocate(int words);
 
     /**
-     * Access all currently existing segments.
+     * Retrieve the AllocatingArena.
      *
-     * @return the segments.
+     * @return the arena.
      */
-    List<GenericSegmentBuilder> getSegments();
+    AllocatingArena getArena();
+
+    /**
+     * Checks if the Segment is writable.
+     *
+     * @return {@code true}
+     */
+    boolean isWritable();
+
+    /**
+     * Retrieve the ID of this segment.
+     *
+     * @return the ID
+     */
+    int getId();
+
+    /**
+     * Sets the ID of the Segment.
+     *
+     * @param id the new ID.
+     */
+    void setId(int id);
+
+    /**
+     * Prepares the underlying ByteBuffer to be written.
+     *
+     * @return
+     */
+    ByteBuffer getSegmentForOutput();
+
 }

--- a/runtime/src/main/java/org/capnproto/GenericSegmentReader.java
+++ b/runtime/src/main/java/org/capnproto/GenericSegmentReader.java
@@ -22,27 +22,19 @@ package org.capnproto;
 
 import java.nio.ByteBuffer;
 
-public class SegmentReader implements GenericSegmentReader {
+/**
+ * Representation of the SegmentBuilder. This Builder is responsible to manage
+ * one Segment of an existing message.
+ */
+public interface GenericSegmentReader extends SegmentDataContainer {
 
-    public final ByteBuffer buffer;
-    private final AllocatedArena arena;
+    GenericSegmentReader EMPTY = new SegmentReader(ByteBuffer.allocate(8), null);
 
-    public SegmentReader(ByteBuffer buffer, AllocatedArena arena) {
-        this.buffer = buffer;
-        this.arena = arena;
-    }
-
-    public long get(int index) {
-        return buffer.getLong(index * Constants.BYTES_PER_WORD);
-    }
-
-    public AllocatedArena getArena() {
-        return arena;
-    }
-
-    @Override
-    public ByteBuffer getBuffer() {
-        return buffer;
-    }
+    /**
+     * Retrieve the Arena containing all Segments.
+     *
+     * @return the arena.
+     */
+    public AllocatedArena getArena();
 
 }

--- a/runtime/src/main/java/org/capnproto/ListBuilder.java
+++ b/runtime/src/main/java/org/capnproto/ListBuilder.java
@@ -23,19 +23,19 @@ package org.capnproto;
 
 public class ListBuilder {
     public interface Factory<T> {
-        T constructBuilder(SegmentBuilder segment, int ptr,
+        T constructBuilder(GenericSegmentBuilder segment, int ptr,
                            int elementCount, int step,
                            int structDataSize, short structPointerCount);
     }
 
-    final SegmentBuilder segment;
+    final GenericSegmentBuilder segment;
     final int ptr; // byte offset to front of list
     final int elementCount;
     final int step; // in bits
     final int structDataSize; // in bits
     final short structPointerCount;
 
-    public ListBuilder(SegmentBuilder segment, int ptr,
+    public ListBuilder(GenericSegmentBuilder segment, int ptr,
                        int elementCount, int step,
                        int structDataSize, short structPointerCount) {
         this.segment = segment;
@@ -52,65 +52,65 @@ public class ListBuilder {
 
     protected boolean _getBooleanElement(int index) {
         long bindex = (long)index * this.step;
-        byte b = this.segment.buffer.get(this.ptr + (int)(bindex / Constants.BITS_PER_BYTE));
+        byte b = this.segment.getBuffer().get(this.ptr + (int)(bindex / Constants.BITS_PER_BYTE));
         return (b & (1 << (bindex % 8))) != 0;
     }
 
     protected byte _getByteElement(int index) {
-        return this.segment.buffer.get(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
+        return this.segment.getBuffer().get(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
     }
 
     protected short _getShortElement(int index) {
-        return this.segment.buffer.getShort(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
+        return this.segment.getBuffer().getShort(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
     }
 
     protected int _getIntElement(int index) {
-        return this.segment.buffer.getInt(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
+        return this.segment.getBuffer().getInt(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
     }
 
     protected long _getLongElement(int index) {
-        return this.segment.buffer.getLong(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
+        return this.segment.getBuffer().getLong(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
     }
 
     protected float _getFloatElement(int index) {
-        return this.segment.buffer.getFloat(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
+        return this.segment.getBuffer().getFloat(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
     }
 
     protected double _getDoubleElement(int index) {
-        return this.segment.buffer.getDouble(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
+        return this.segment.getBuffer().getDouble(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
     }
 
     protected void _setBooleanElement(int index, boolean value) {
         long bitOffset = index * this.step;
         byte bitnum = (byte)(bitOffset % 8);
         int position = (int)(this.ptr + (bitOffset / 8));
-        byte oldValue = this.segment.buffer.get(position);
-        this.segment.buffer.put(position,
+        byte oldValue = this.segment.getBuffer().get(position);
+        this.segment.getBuffer().put(position,
                                 (byte)((oldValue & (~(1 << bitnum))) | (( value ? 1 : 0) << bitnum)));
     }
 
     protected void _setByteElement(int index, byte value) {
-        this.segment.buffer.put(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE), value);
+        this.segment.getBuffer().put(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE), value);
     }
 
     protected void _setShortElement(int index, short value) {
-        this.segment.buffer.putShort(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE), value);
+        this.segment.getBuffer().putShort(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE), value);
     }
 
     protected void _setIntElement(int index, int value) {
-        this.segment.buffer.putInt(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE), value);
+        this.segment.getBuffer().putInt(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE), value);
     }
 
     protected void _setLongElement(int index, long value) {
-        this.segment.buffer.putLong(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE), value);
+        this.segment.getBuffer().putLong(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE), value);
     }
 
     protected void _setFloatElement(int index, float value) {
-        this.segment.buffer.putFloat(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE), value);
+        this.segment.getBuffer().putFloat(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE), value);
     }
 
     protected void _setDoubleElement(int index, double value) {
-        this.segment.buffer.putDouble(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE), value);
+        this.segment.getBuffer().putDouble(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE), value);
     }
 
     protected final <T> T _getStructElement(StructBuilder.Factory<T> factory, int index) {

--- a/runtime/src/main/java/org/capnproto/ListFactory.java
+++ b/runtime/src/main/java/org/capnproto/ListFactory.java
@@ -32,8 +32,8 @@ public abstract class ListFactory<Builder, Reader extends ListReader>
     final byte elementSize;
     ListFactory(byte elementSize) {this.elementSize = elementSize;}
 
-    public final Reader fromPointerReaderRefDefault(SegmentReader segment, int pointer,
-                                                    SegmentReader defaultSegment, int defaultOffset,
+    public final Reader fromPointerReaderRefDefault(SegmentDataContainer segment, int pointer,
+                                                    SegmentDataContainer defaultSegment, int defaultOffset,
                                                     int nestingLimit) {
         return WireHelpers.readListPointer(this,
                                            segment,
@@ -44,12 +44,12 @@ public abstract class ListFactory<Builder, Reader extends ListReader>
                                            nestingLimit);
     }
 
-    public final Reader fromPointerReader(SegmentReader segment, int pointer, int nestingLimit) {
+    public final Reader fromPointerReader(SegmentDataContainer segment, int pointer, int nestingLimit) {
         return fromPointerReaderRefDefault(segment, pointer, null, 0, nestingLimit);
     }
 
-    public Builder fromPointerBuilderRefDefault(SegmentBuilder segment, int pointer,
-                                                SegmentReader defaultSegment, int defaultOffset) {
+    public Builder fromPointerBuilderRefDefault(GenericSegmentBuilder segment, int pointer,
+                                                SegmentDataContainer defaultSegment, int defaultOffset) {
         return WireHelpers.getWritableListPointer(this,
                                                   pointer,
                                                   segment,
@@ -58,7 +58,7 @@ public abstract class ListFactory<Builder, Reader extends ListReader>
                                                   defaultOffset);
     }
 
-    public Builder fromPointerBuilder(SegmentBuilder segment, int pointer) {
+    public Builder fromPointerBuilder(GenericSegmentBuilder segment, int pointer) {
         return WireHelpers.getWritableListPointer(this,
                                                   pointer,
                                                   segment,
@@ -66,11 +66,11 @@ public abstract class ListFactory<Builder, Reader extends ListReader>
                                                   null, 0);
     }
 
-    public Builder initFromPointerBuilder(SegmentBuilder segment, int pointer, int elementCount) {
+    public Builder initFromPointerBuilder(GenericSegmentBuilder segment, int pointer, int elementCount) {
         return WireHelpers.initListPointer(this, pointer, segment, elementCount, this.elementSize);
     }
 
-    public final void setPointerBuilder(SegmentBuilder segment, int pointer, Reader value) {
+    public final void setPointerBuilder(GenericSegmentBuilder segment, int pointer, Reader value) {
         WireHelpers.setListPointer(segment, pointer, value);
     }
 }

--- a/runtime/src/main/java/org/capnproto/ListList.java
+++ b/runtime/src/main/java/org/capnproto/ListList.java
@@ -32,7 +32,7 @@ public final class ListList {
             this.factory = factory;
         }
 
-        public final Reader<ElementReader> constructReader(SegmentReader segment,
+        public final Reader<ElementReader> constructReader(SegmentDataContainer segment,
                                                              int ptr,
                                                              int elementCount, int step,
                                                              int structDataSize, short structPointerCount,
@@ -40,7 +40,7 @@ public final class ListList {
             return new Reader<ElementReader>(factory, segment, ptr, elementCount, step, structDataSize, structPointerCount, nestingLimit);
         }
 
-        public final Builder<ElementBuilder> constructBuilder(SegmentBuilder segment,
+        public final Builder<ElementBuilder> constructBuilder(GenericSegmentBuilder segment,
                                                               int ptr,
                                                               int elementCount, int step,
                                                               int structDataSize, short structPointerCount) {
@@ -52,7 +52,7 @@ public final class ListList {
         private final FromPointerReader<T> factory;
 
         public Reader(FromPointerReader<T> factory,
-                      SegmentReader segment,
+                      SegmentDataContainer segment,
                       int ptr,
                       int elementCount, int step,
                       int structDataSize, short structPointerCount,
@@ -70,7 +70,7 @@ public final class ListList {
         private final ListFactory<T, ?> factory;
 
         public Builder(ListFactory<T, ?> factory,
-                       SegmentBuilder segment, int ptr,
+                       GenericSegmentBuilder segment, int ptr,
                        int elementCount, int step,
                        int structDataSize, short structPointerCount){
             super(segment, ptr, elementCount, step, structDataSize, structPointerCount);

--- a/runtime/src/main/java/org/capnproto/ListReader.java
+++ b/runtime/src/main/java/org/capnproto/ListReader.java
@@ -23,14 +23,14 @@ package org.capnproto;
 
 public class ListReader {
     public interface Factory<T> {
-        T constructReader(SegmentReader segment,
+        T constructReader(SegmentDataContainer segment,
                           int ptr,
                           int elementCount, int step,
                           int structDataSize, short structPointerCount,
                           int nestingLimit);
     }
 
-    final SegmentReader segment;
+    final SegmentDataContainer segment;
     final int ptr; // byte offset to front of list
     final int elementCount;
     final int step; // in bits
@@ -48,7 +48,7 @@ public class ListReader {
         this.nestingLimit = 0x7fffffff;
     }
 
-    public ListReader(SegmentReader segment, int ptr,
+    public ListReader(SegmentDataContainer segment, int ptr,
                       int elementCount, int step,
                       int structDataSize, short structPointerCount,
                       int nestingLimit) {
@@ -68,32 +68,32 @@ public class ListReader {
 
     protected boolean _getBooleanElement(int index) {
         long bindex = (long)index * this.step;
-        byte b = this.segment.buffer.get(this.ptr + (int)(bindex / Constants.BITS_PER_BYTE));
+        byte b = this.segment.getBuffer().get(this.ptr + (int)(bindex / Constants.BITS_PER_BYTE));
         return (b & (1 << (bindex % 8))) != 0;
     }
 
     protected byte _getByteElement(int index) {
-        return this.segment.buffer.get(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
+        return this.segment.getBuffer().get(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
     }
 
     protected short _getShortElement(int index) {
-        return this.segment.buffer.getShort(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
+        return this.segment.getBuffer().getShort(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
     }
 
     protected int _getIntElement(int index) {
-        return this.segment.buffer.getInt(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
+        return this.segment.getBuffer().getInt(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
     }
 
     protected long _getLongElement(int index) {
-        return this.segment.buffer.getLong(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
+        return this.segment.getBuffer().getLong(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
     }
 
     protected float _getFloatElement(int index) {
-        return this.segment.buffer.getFloat(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
+        return this.segment.getBuffer().getFloat(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
     }
 
     protected double _getDoubleElement(int index) {
-        return this.segment.buffer.getDouble(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
+        return this.segment.getBuffer().getDouble(this.ptr + (int)((long)index * this.step / Constants.BITS_PER_BYTE));
     }
 
     protected <T> T _getStructElement(StructReader.Factory<T> factory, int index) {

--- a/runtime/src/main/java/org/capnproto/MessageBuilder.java
+++ b/runtime/src/main/java/org/capnproto/MessageBuilder.java
@@ -76,7 +76,20 @@ public final class MessageBuilder {
         return this.getRootInternal().initAs(factory);
     }
 
+    /**
+     * @Deprecated use {@link MessageBuilder#getArena()} instead.
+     */
+    @Deprecated
     public final java.nio.ByteBuffer[] getSegmentsForOutput() {
         return this.arena.getSegmentsForOutput();
+    }
+
+    /**
+     * provide the {@link AllocatingArena} for output.
+     *
+     * @return the arena.
+     */
+    public AllocatingArena getArena() {
+        return arena;
     }
 }

--- a/runtime/src/main/java/org/capnproto/MessageBuilder.java
+++ b/runtime/src/main/java/org/capnproto/MessageBuilder.java
@@ -49,10 +49,10 @@ public final class MessageBuilder {
     }
 
     private AnyPointer.Builder getRootInternal() {
-        SegmentBuilder rootSegment = this.arena.getSegment(0);
+        GenericSegmentBuilder rootSegment = this.arena.tryGetSegment(0);
         if (rootSegment.currentSize() == 0) {
             int location = rootSegment.allocate(1);
-            if (location == SegmentBuilder.FAILED_ALLOCATION) {
+            if (location == GenericSegmentBuilder.FAILED_ALLOCATION) {
                 throw new Error("could not allocate root pointer");
             }
             if (location != 0) {

--- a/runtime/src/main/java/org/capnproto/MessageBuilder.java
+++ b/runtime/src/main/java/org/capnproto/MessageBuilder.java
@@ -23,7 +23,15 @@ package org.capnproto;
 
 public final class MessageBuilder {
 
-    private final BuilderArena arena;
+    private final AllocatingArena arena;
+
+    /**
+     * Creates a MessageBuilder with an injected custom AllocatingArena.
+     * @param arena The custom AllocatingArena.
+     */
+    public MessageBuilder(AllocatingArena arena) {
+        this.arena = arena;
+    }
 
     public MessageBuilder() {
         this.arena = new BuilderArena(BuilderArena.SUGGESTED_FIRST_SEGMENT_WORDS,
@@ -41,7 +49,7 @@ public final class MessageBuilder {
     }
 
     private AnyPointer.Builder getRootInternal() {
-        SegmentBuilder rootSegment = this.arena.segments.get(0);
+        SegmentBuilder rootSegment = this.arena.getSegment(0);
         if (rootSegment.currentSize() == 0) {
             int location = rootSegment.allocate(1);
             if (location == SegmentBuilder.FAILED_ALLOCATION) {

--- a/runtime/src/main/java/org/capnproto/MessageBuilder.java
+++ b/runtime/src/main/java/org/capnproto/MessageBuilder.java
@@ -77,7 +77,7 @@ public final class MessageBuilder {
     }
 
     /**
-     * @Deprecated use {@link MessageBuilder#getArena()} instead.
+     * @deprecated use {@link MessageBuilder#getArena()} instead.
      */
     @Deprecated
     public final java.nio.ByteBuffer[] getSegmentsForOutput() {

--- a/runtime/src/main/java/org/capnproto/MessageReader.java
+++ b/runtime/src/main/java/org/capnproto/MessageReader.java
@@ -18,14 +18,26 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
 package org.capnproto;
 
 import java.nio.ByteBuffer;
 
 public final class MessageReader {
-    final ReaderArena arena;
+
+    final AllocatedArena arena;
     final int nestingLimit;
+
+    /**
+     * Construct a MessageReader with an injected custom {@link Arena}, that can
+     * provide custom {@link GenericSegmentReader}.
+     *
+     * @param arena the Arena implementation.
+     */
+    public MessageReader(AllocatedArena arena) {
+        this.arena = arena;
+        // as the nesting limit is currently completely ignored, we use the default.
+        this.nestingLimit = ReaderOptions.DEFAULT_NESTING_LIMIT;
+    }
 
     public MessageReader(ByteBuffer[] segmentSlices, ReaderOptions options) {
         this.nestingLimit = options.nestingLimit;
@@ -33,7 +45,7 @@ public final class MessageReader {
     }
 
     public <T> T getRoot(FromPointerReader<T> factory) {
-        SegmentReader segment = this.arena.tryGetSegment(0);
+        GenericSegmentReader segment = this.arena.tryGetSegment(0);
         AnyPointer.Reader any = new AnyPointer.Reader(segment, 0, this.nestingLimit);
         return any.getAs(factory);
     }

--- a/runtime/src/main/java/org/capnproto/PrimitiveList.java
+++ b/runtime/src/main/java/org/capnproto/PrimitiveList.java
@@ -26,7 +26,7 @@ public class PrimitiveList {
         public static final class Factory extends ListFactory<Builder, Reader> {
             Factory() {super (ElementSize.VOID); }
 
-            public final Reader constructReader(SegmentReader segment,
+            public final Reader constructReader(SegmentDataContainer segment,
                                                   int ptr,
                                                   int elementCount, int step,
                                                   int structDataSize, short structPointerCount,
@@ -34,7 +34,7 @@ public class PrimitiveList {
                 return new Reader(segment, ptr, elementCount, step, structDataSize, structPointerCount, nestingLimit);
             }
 
-            public final Builder constructBuilder(SegmentBuilder segment,
+            public final Builder constructBuilder(GenericSegmentBuilder segment,
                                                     int ptr,
                                                     int elementCount, int step,
                                                     int structDataSize, short structPointerCount) {
@@ -45,7 +45,7 @@ public class PrimitiveList {
         public static final Factory factory = new Factory();
 
         public static final class Reader extends ListReader {
-            public Reader(SegmentReader segment,
+            public Reader(SegmentDataContainer segment,
                           int ptr,
                           int elementCount, int step,
                           int structDataSize, short structPointerCount,
@@ -59,7 +59,7 @@ public class PrimitiveList {
         }
 
         public static final class Builder extends ListBuilder {
-            public Builder(SegmentBuilder segment, int ptr,
+            public Builder(GenericSegmentBuilder segment, int ptr,
                            int elementCount, int step,
                            int structDataSize, short structPointerCount){
                 super(segment, ptr, elementCount, step, structDataSize, structPointerCount);
@@ -77,7 +77,7 @@ public class PrimitiveList {
     public static class Boolean {
         public static final class Factory extends ListFactory<Builder, Reader> {
             Factory() {super (ElementSize.BIT); }
-            public final Reader constructReader(SegmentReader segment,
+            public final Reader constructReader(SegmentDataContainer segment,
                                                   int ptr,
                                                   int elementCount, int step,
                                                   int structDataSize, short structPointerCount,
@@ -85,7 +85,7 @@ public class PrimitiveList {
                 return new Reader(segment, ptr, elementCount, step, structDataSize, structPointerCount, nestingLimit);
             }
 
-            public final Builder constructBuilder(SegmentBuilder segment,
+            public final Builder constructBuilder(GenericSegmentBuilder segment,
                                                     int ptr,
                                                     int elementCount, int step,
                                                     int structDataSize, short structPointerCount) {
@@ -95,7 +95,7 @@ public class PrimitiveList {
         public static final Factory factory = new Factory();
 
         public static final class Reader extends ListReader {
-            public Reader(SegmentReader segment,
+            public Reader(SegmentDataContainer segment,
                           int ptr,
                           int elementCount, int step,
                           int structDataSize, short structPointerCount,
@@ -109,7 +109,7 @@ public class PrimitiveList {
         }
 
         public static final class Builder extends ListBuilder {
-            public Builder(SegmentBuilder segment, int ptr,
+            public Builder(GenericSegmentBuilder segment, int ptr,
                            int elementCount, int step,
                            int structDataSize, short structPointerCount){
                 super(segment, ptr, elementCount, step, structDataSize, structPointerCount);
@@ -134,7 +134,7 @@ public class PrimitiveList {
     public static class Byte {
         public static final class Factory extends ListFactory<Builder, Reader> {
             Factory() {super (ElementSize.BYTE); }
-            public final Reader constructReader(SegmentReader segment,
+            public final Reader constructReader(SegmentDataContainer segment,
                                                   int ptr,
                                                   int elementCount, int step,
                                                   int structDataSize, short structPointerCount,
@@ -142,7 +142,7 @@ public class PrimitiveList {
                 return new Reader(segment, ptr, elementCount, step, structDataSize, structPointerCount, nestingLimit);
             }
 
-            public final Builder constructBuilder(SegmentBuilder segment,
+            public final Builder constructBuilder(GenericSegmentBuilder segment,
                                                     int ptr,
                                                     int elementCount, int step,
                                                     int structDataSize, short structPointerCount) {
@@ -152,7 +152,7 @@ public class PrimitiveList {
         public static final Factory factory = new Factory();
 
         public static final class Reader extends ListReader {
-            public Reader(SegmentReader segment,
+            public Reader(SegmentDataContainer segment,
                           int ptr,
                           int elementCount, int step,
                           int structDataSize, short structPointerCount,
@@ -166,7 +166,7 @@ public class PrimitiveList {
         }
 
         public static final class Builder extends ListBuilder {
-            public Builder(SegmentBuilder segment, int ptr,
+            public Builder(GenericSegmentBuilder segment, int ptr,
                            int elementCount, int step,
                            int structDataSize, short structPointerCount){
                 super(segment, ptr, elementCount, step, structDataSize, structPointerCount);
@@ -191,7 +191,7 @@ public class PrimitiveList {
     public static class Short {
         public static final class Factory extends ListFactory<Builder, Reader> {
             Factory() {super (ElementSize.TWO_BYTES); }
-            public final Reader constructReader(SegmentReader segment,
+            public final Reader constructReader(SegmentDataContainer segment,
                                                   int ptr,
                                                   int elementCount, int step,
                                                   int structDataSize, short structPointerCount,
@@ -199,7 +199,7 @@ public class PrimitiveList {
                 return new Reader(segment, ptr, elementCount, step, structDataSize, structPointerCount, nestingLimit);
             }
 
-            public final Builder constructBuilder(SegmentBuilder segment,
+            public final Builder constructBuilder(GenericSegmentBuilder segment,
                                                     int ptr,
                                                     int elementCount, int step,
                                                     int structDataSize, short structPointerCount) {
@@ -210,7 +210,7 @@ public class PrimitiveList {
         public static final Factory factory = new Factory();
 
         public static final class Reader extends ListReader {
-            public Reader(SegmentReader segment,
+            public Reader(SegmentDataContainer segment,
                           int ptr,
                           int elementCount, int step,
                           int structDataSize, short structPointerCount,
@@ -224,7 +224,7 @@ public class PrimitiveList {
         }
 
         public static final class Builder extends ListBuilder {
-            public Builder(SegmentBuilder segment, int ptr,
+            public Builder(GenericSegmentBuilder segment, int ptr,
                            int elementCount, int step,
                            int structDataSize, short structPointerCount){
                 super(segment, ptr, elementCount, step, structDataSize, structPointerCount);
@@ -249,7 +249,7 @@ public class PrimitiveList {
     public static class Int {
         public static final class Factory extends ListFactory<Builder, Reader> {
             Factory() {super (ElementSize.FOUR_BYTES); }
-            public final Reader constructReader(SegmentReader segment,
+            public final Reader constructReader(SegmentDataContainer segment,
                                                   int ptr,
                                                   int elementCount, int step,
                                                   int structDataSize, short structPointerCount,
@@ -257,7 +257,7 @@ public class PrimitiveList {
                 return new Reader(segment, ptr, elementCount, step, structDataSize, structPointerCount, nestingLimit);
             }
 
-            public final Builder constructBuilder(SegmentBuilder segment,
+            public final Builder constructBuilder(GenericSegmentBuilder segment,
                                                     int ptr,
                                                     int elementCount, int step,
                                                     int structDataSize, short structPointerCount) {
@@ -268,7 +268,7 @@ public class PrimitiveList {
         public static final Factory factory = new Factory();
 
         public static final class Reader extends ListReader {
-            public Reader(SegmentReader segment,
+            public Reader(SegmentDataContainer segment,
                           int ptr,
                           int elementCount, int step,
                           int structDataSize, short structPointerCount,
@@ -282,7 +282,7 @@ public class PrimitiveList {
         }
 
         public static final class Builder extends ListBuilder {
-            public Builder(SegmentBuilder segment, int ptr,
+            public Builder(GenericSegmentBuilder segment, int ptr,
                            int elementCount, int step,
                            int structDataSize, short structPointerCount){
                 super(segment, ptr, elementCount, step, structDataSize, structPointerCount);
@@ -307,7 +307,7 @@ public class PrimitiveList {
     public static class Float {
         public static final class Factory extends ListFactory<Builder, Reader> {
             Factory() {super (ElementSize.FOUR_BYTES); }
-            public final Reader constructReader(SegmentReader segment,
+            public final Reader constructReader(SegmentDataContainer segment,
                                                   int ptr,
                                                   int elementCount, int step,
                                                   int structDataSize, short structPointerCount,
@@ -315,7 +315,7 @@ public class PrimitiveList {
                 return new Reader(segment, ptr, elementCount, step, structDataSize, structPointerCount, nestingLimit);
             }
 
-            public final Builder constructBuilder(SegmentBuilder segment,
+            public final Builder constructBuilder(GenericSegmentBuilder segment,
                                                     int ptr,
                                                     int elementCount, int step,
                                                     int structDataSize, short structPointerCount) {
@@ -325,7 +325,7 @@ public class PrimitiveList {
         public static final Factory factory = new Factory();
 
         public static final class Reader extends ListReader {
-            public Reader(SegmentReader segment,
+            public Reader(SegmentDataContainer segment,
                           int ptr,
                           int elementCount, int step,
                           int structDataSize, short structPointerCount,
@@ -339,7 +339,7 @@ public class PrimitiveList {
         }
 
         public static final class Builder extends ListBuilder {
-            public Builder(SegmentBuilder segment, int ptr,
+            public Builder(GenericSegmentBuilder segment, int ptr,
                            int elementCount, int step,
                            int structDataSize, short structPointerCount){
                 super(segment, ptr, elementCount, step, structDataSize, structPointerCount);
@@ -365,7 +365,7 @@ public class PrimitiveList {
     public static class Long {
         public static final class Factory extends ListFactory<Builder, Reader> {
             Factory() {super (ElementSize.EIGHT_BYTES); }
-            public final Reader constructReader(SegmentReader segment,
+            public final Reader constructReader(SegmentDataContainer segment,
                                                   int ptr,
                                                   int elementCount, int step,
                                                   int structDataSize, short structPointerCount,
@@ -373,7 +373,7 @@ public class PrimitiveList {
                 return new Reader(segment, ptr, elementCount, step, structDataSize, structPointerCount, nestingLimit);
             }
 
-            public final Builder constructBuilder(SegmentBuilder segment,
+            public final Builder constructBuilder(GenericSegmentBuilder segment,
                                                     int ptr,
                                                     int elementCount, int step,
                                                     int structDataSize, short structPointerCount) {
@@ -383,7 +383,7 @@ public class PrimitiveList {
         public static final Factory factory = new Factory();
 
         public static final class Reader extends ListReader {
-            public Reader(SegmentReader segment,
+            public Reader(SegmentDataContainer segment,
                           int ptr,
                           int elementCount, int step,
                           int structDataSize, short structPointerCount,
@@ -397,7 +397,7 @@ public class PrimitiveList {
         }
 
         public static final class Builder extends ListBuilder {
-            public Builder(SegmentBuilder segment, int ptr,
+            public Builder(GenericSegmentBuilder segment, int ptr,
                            int elementCount, int step,
                            int structDataSize, short structPointerCount){
                 super(segment, ptr, elementCount, step, structDataSize, structPointerCount);
@@ -422,7 +422,7 @@ public class PrimitiveList {
     public static class Double {
         public static final class Factory extends ListFactory<Builder, Reader> {
             Factory() {super (ElementSize.EIGHT_BYTES); }
-            public final Reader constructReader(SegmentReader segment,
+            public final Reader constructReader(SegmentDataContainer segment,
                                                   int ptr,
                                                   int elementCount, int step,
                                                   int structDataSize, short structPointerCount,
@@ -430,7 +430,7 @@ public class PrimitiveList {
                 return new Reader(segment, ptr, elementCount, step, structDataSize, structPointerCount, nestingLimit);
             }
 
-            public final Builder constructBuilder(SegmentBuilder segment,
+            public final Builder constructBuilder(GenericSegmentBuilder segment,
                                                     int ptr,
                                                     int elementCount, int step,
                                                     int structDataSize, short structPointerCount) {
@@ -440,7 +440,7 @@ public class PrimitiveList {
         public static final Factory factory = new Factory();
 
         public static final class Reader extends ListReader {
-            public Reader(SegmentReader segment,
+            public Reader(SegmentDataContainer segment,
                           int ptr,
                           int elementCount, int step,
                           int structDataSize, short structPointerCount,
@@ -454,7 +454,7 @@ public class PrimitiveList {
         }
 
         public static final class Builder extends ListBuilder {
-            public Builder(SegmentBuilder segment, int ptr,
+            public Builder(GenericSegmentBuilder segment, int ptr,
                            int elementCount, int step,
                            int structDataSize, short structPointerCount){
                 super(segment, ptr, elementCount, step, structDataSize, structPointerCount);

--- a/runtime/src/main/java/org/capnproto/ReaderArena.java
+++ b/runtime/src/main/java/org/capnproto/ReaderArena.java
@@ -18,28 +18,32 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
 package org.capnproto;
 
 import java.util.ArrayList;
 import java.nio.ByteBuffer;
+import java.util.List;
 
-public final class ReaderArena implements Arena {
+public final class ReaderArena implements AllocatedArena {
 
     public long limit;
     // current limit
 
-    public final ArrayList<SegmentReader> segments;
+    private final List<GenericSegmentReader> segments;
 
     public ReaderArena(ByteBuffer[] segmentSlices, long traversalLimitInWords) {
         this.limit = traversalLimitInWords;
-        this.segments = new ArrayList<SegmentReader>();
-        for(int ii = 0; ii < segmentSlices.length; ++ii) {
+        this.segments = new ArrayList<GenericSegmentReader>();
+        for (int ii = 0; ii < segmentSlices.length; ++ii) {
             this.segments.add(new SegmentReader(segmentSlices[ii], this));
         }
     }
 
-    public SegmentReader tryGetSegment(int id) {
+    public List<GenericSegmentReader> getSegments() {
+        return segments;
+    }
+
+    public GenericSegmentReader tryGetSegment(int id) {
         return segments.get(id);
     }
 

--- a/runtime/src/main/java/org/capnproto/SegmentBuilder.java
+++ b/runtime/src/main/java/org/capnproto/SegmentBuilder.java
@@ -18,7 +18,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
 package org.capnproto;
 
 import java.nio.ByteBuffer;
@@ -29,9 +28,12 @@ public final class SegmentBuilder extends SegmentReader {
 
     public int pos = 0; // in words
     public int id = 0;
+    // store the AllocatingArena
+    private final AllocatingArena arena;
 
-    public SegmentBuilder(ByteBuffer buf, Arena arena) {
+    public SegmentBuilder(ByteBuffer buf, AllocatingArena arena) {
         super(buf, arena);
+        this.arena = arena;
     }
 
     // the total number of words the buffer can hold
@@ -60,8 +62,8 @@ public final class SegmentBuilder extends SegmentReader {
         }
     }
 
-    public final BuilderArena getArena() {
-        return (BuilderArena)this.arena;
+    public final AllocatingArena getArena() {
+        return this.arena;
     }
 
     public final boolean isWritable() {

--- a/runtime/src/main/java/org/capnproto/SegmentDataContainer.java
+++ b/runtime/src/main/java/org/capnproto/SegmentDataContainer.java
@@ -22,27 +22,30 @@ package org.capnproto;
 
 import java.nio.ByteBuffer;
 
-public class SegmentReader implements GenericSegmentReader {
+/**
+ * A Container for Segments.
+ */
+public interface SegmentDataContainer {
 
-    public final ByteBuffer buffer;
-    private final AllocatedArena arena;
+    /**
+     * Retrieves a long from a word index.
+     *
+     * @param index the word index.
+     * @return the long value.
+     */
+    long get(int index);
 
-    public SegmentReader(ByteBuffer buffer, AllocatedArena arena) {
-        this.buffer = buffer;
-        this.arena = arena;
-    }
+    /**
+     * Retrieve the internal {@link ByteBuffer}.
+     *
+     * @return the buffer.
+     */
+    ByteBuffer getBuffer();
 
-    public long get(int index) {
-        return buffer.getLong(index * Constants.BYTES_PER_WORD);
-    }
-
-    public AllocatedArena getArena() {
-        return arena;
-    }
-
-    @Override
-    public ByteBuffer getBuffer() {
-        return buffer;
-    }
-
+    /**
+     * Retrieve the Arena used in this SegmentDataContainer.
+     *
+     * @return the Arena.
+     */
+    Arena getArena();
 }

--- a/runtime/src/main/java/org/capnproto/SegmentReader.java
+++ b/runtime/src/main/java/org/capnproto/SegmentReader.java
@@ -18,7 +18,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
 package org.capnproto;
 
 import java.nio.ByteBuffer;
@@ -26,7 +25,7 @@ import java.nio.ByteBuffer;
 public class SegmentReader {
 
     public final ByteBuffer buffer;
-    final Arena arena;
+    private final Arena arena;
 
     public SegmentReader(ByteBuffer buffer, Arena arena) {
         this.buffer = buffer;
@@ -37,5 +36,9 @@ public class SegmentReader {
 
     public final long get(int index) {
         return buffer.getLong(index * Constants.BYTES_PER_WORD);
+    }
+
+    Arena getArena() {
+        return arena;
     }
 }

--- a/runtime/src/main/java/org/capnproto/Serialize.java
+++ b/runtime/src/main/java/org/capnproto/Serialize.java
@@ -152,7 +152,7 @@ public final class Serialize {
     }
 
     public static long computeSerializedSizeInWords(MessageBuilder message) {
-        final ByteBuffer[] segments = message.getSegmentsForOutput();
+        final ByteBuffer[] segments = message.getArena().getSegmentsForOutput();
 
         // From the capnproto documentation:
         // "When transmitting over a stream, the following should be sent..."
@@ -177,7 +177,7 @@ public final class Serialize {
 
     public static void write(WritableByteChannel outputChannel,
                              MessageBuilder message) throws IOException {
-        ByteBuffer[] segments = message.getSegmentsForOutput();
+        ByteBuffer[] segments = message.getArena().getSegmentsForOutput();
         int tableSize = (segments.length + 2) & (~1);
 
         ByteBuffer table = ByteBuffer.allocate(4 * tableSize);

--- a/runtime/src/main/java/org/capnproto/SetPointerBuilder.java
+++ b/runtime/src/main/java/org/capnproto/SetPointerBuilder.java
@@ -22,5 +22,5 @@
 package org.capnproto;
 
 public interface SetPointerBuilder<Builder, Reader> {
-    void setPointerBuilder(SegmentBuilder segment, int pointer, Reader value);
+    void setPointerBuilder(GenericSegmentBuilder segment, int pointer, Reader value);
 }

--- a/runtime/src/main/java/org/capnproto/StructBuilder.java
+++ b/runtime/src/main/java/org/capnproto/StructBuilder.java
@@ -23,19 +23,19 @@ package org.capnproto;
 
 public class StructBuilder {
     public interface Factory<T> {
-        T constructBuilder(SegmentBuilder segment, int data, int pointers, int dataSize,
-                           short pointerCount);
+        T constructBuilder(GenericSegmentBuilder segment, int data, int pointers, int dataSize,
+                short pointerCount);
         StructSize structSize();
     }
 
-    protected final SegmentBuilder segment;
+    protected final GenericSegmentBuilder segment;
     protected final int data; // byte offset to data section
     protected final int pointers; // word offset of pointer section
     protected final int dataSize; // in bits
     protected final short pointerCount;
 
-    public StructBuilder(SegmentBuilder segment, int data,
-                         int pointers, int dataSize, short pointerCount) {
+    public StructBuilder(GenericSegmentBuilder segment, int data,
+            int pointers, int dataSize, short pointerCount) {
         this.segment = segment;
         this.data = data;
         this.pointers = pointers;
@@ -46,7 +46,7 @@ public class StructBuilder {
     protected final boolean _getBooleanField(int offset) {
         int bitOffset = offset;
         int position = this.data + (bitOffset / 8);
-        return (this.segment.buffer.get(position) & (1 << (bitOffset % 8))) != 0;
+        return (this.segment.getBuffer().get(position) & (1 << (bitOffset % 8))) != 0;
     }
 
     protected final boolean _getBooleanField(int offset, boolean mask) {
@@ -55,11 +55,11 @@ public class StructBuilder {
 
     protected final void _setBooleanField(int offset, boolean value) {
         int bitOffset = offset;
-        byte bitnum = (byte)(bitOffset % 8);
+        byte bitnum = (byte) (bitOffset % 8);
         int position = this.data + (bitOffset / 8);
-        byte oldValue = this.segment.buffer.get(position);
-        this.segment.buffer.put(position,
-                                (byte)((oldValue & (~(1 << bitnum))) | (( value ? 1 : 0) << bitnum)));
+        byte oldValue = this.segment.getBuffer().get(position);
+        this.segment.getBuffer().put(position,
+                (byte) ((oldValue & (~(1 << bitnum))) | ((value ? 1 : 0) << bitnum)));
     }
 
     protected final void _setBooleanField(int offset, boolean value, boolean mask) {
@@ -67,15 +67,15 @@ public class StructBuilder {
     }
 
     protected final byte _getByteField(int offset) {
-        return this.segment.buffer.get(this.data + offset);
+        return this.segment.getBuffer().get(this.data + offset);
     }
 
     protected final byte _getByteField(int offset, byte mask) {
-        return (byte)(this._getByteField(offset) ^ mask);
+        return (byte) (this._getByteField(offset) ^ mask);
     }
 
     protected final void _setByteField(int offset, byte value) {
-        this.segment.buffer.put(this.data + offset, value);
+        this.segment.getBuffer().put(this.data + offset, value);
     }
 
     protected final void _setByteField(int offset, byte value, byte mask) {
@@ -83,23 +83,23 @@ public class StructBuilder {
     }
 
     protected final short _getShortField(int offset) {
-        return this.segment.buffer.getShort(this.data + offset * 2);
+        return this.segment.getBuffer().getShort(this.data + offset * 2);
     }
 
     protected final short _getShortField(int offset, short mask) {
-        return (short)(this._getShortField(offset) ^ mask);
+        return (short) (this._getShortField(offset) ^ mask);
     }
 
     protected final void _setShortField(int offset, short value) {
-        this.segment.buffer.putShort(this.data + offset * 2, value);
+        this.segment.getBuffer().putShort(this.data + offset * 2, value);
     }
 
     protected final void _setShortField(int offset, short value, short mask) {
-        this._setShortField(offset, (short)(value ^ mask));
+        this._setShortField(offset, (short) (value ^ mask));
     }
 
     protected final int _getIntField(int offset) {
-        return this.segment.buffer.getInt(this.data + offset * 4);
+        return this.segment.getBuffer().getInt(this.data + offset * 4);
     }
 
     protected final int _getIntField(int offset, int mask) {
@@ -107,7 +107,7 @@ public class StructBuilder {
     }
 
     protected final void _setIntField(int offset, int value) {
-        this.segment.buffer.putInt(this.data + offset * 4, value);
+        this.segment.getBuffer().putInt(this.data + offset * 4, value);
     }
 
     protected final void _setIntField(int offset, int value, int mask) {
@@ -115,7 +115,7 @@ public class StructBuilder {
     }
 
     protected final long _getLongField(int offset) {
-        return this.segment.buffer.getLong(this.data + offset * 8);
+        return this.segment.getBuffer().getLong(this.data + offset * 8);
     }
 
     protected final long _getLongField(int offset, long mask) {
@@ -123,7 +123,7 @@ public class StructBuilder {
     }
 
     protected final void _setLongField(int offset, long value) {
-        this.segment.buffer.putLong(this.data + offset * 8, value);
+        this.segment.getBuffer().putLong(this.data + offset * 8, value);
     }
 
     protected final void _setLongField(int offset, long value, long mask) {
@@ -131,49 +131,49 @@ public class StructBuilder {
     }
 
     protected final float _getFloatField(int offset) {
-        return this.segment.buffer.getFloat(this.data + offset * 4);
+        return this.segment.getBuffer().getFloat(this.data + offset * 4);
     }
 
     protected final float _getFloatField(int offset, int mask) {
         return Float.intBitsToFloat(
-            this.segment.buffer.getInt(this.data + offset * 4) ^ mask);
+                this.segment.getBuffer().getInt(this.data + offset * 4) ^ mask);
     }
 
     protected final void _setFloatField(int offset, float value) {
-        this.segment.buffer.putFloat(this.data + offset * 4, value);
+        this.segment.getBuffer().putFloat(this.data + offset * 4, value);
     }
 
     protected final void _setFloatField(int offset, float value, int mask) {
-        this.segment.buffer.putInt(this.data + offset * 4,
-                                   Float.floatToIntBits(value) ^ mask);
+        this.segment.getBuffer().putInt(this.data + offset * 4,
+                Float.floatToIntBits(value) ^ mask);
     }
 
     protected final double _getDoubleField(int offset) {
-        return this.segment.buffer.getDouble(this.data + offset * 8);
+        return this.segment.getBuffer().getDouble(this.data + offset * 8);
     }
 
     protected final double _getDoubleField(int offset, long mask) {
         return Double.longBitsToDouble(
-            this.segment.buffer.getLong(this.data + offset * 8) ^ mask);
+                this.segment.getBuffer().getLong(this.data + offset * 8) ^ mask);
     }
 
     protected final void _setDoubleField(int offset, double value) {
-        this.segment.buffer.putDouble(this.data + offset * 8, value);
+        this.segment.getBuffer().putDouble(this.data + offset * 8, value);
     }
 
     protected final void _setDoubleField(int offset, double value, long mask) {
-        this.segment.buffer.putLong(this.data + offset * 8,
-                                    Double.doubleToLongBits(value) ^ mask);
+        this.segment.getBuffer().putLong(this.data + offset * 8,
+                Double.doubleToLongBits(value) ^ mask);
     }
 
     protected final boolean _pointerFieldIsNull(int ptrIndex) {
-        return ptrIndex >= this.pointerCount || this.segment.buffer.getLong((this.pointers + ptrIndex) * Constants.BYTES_PER_WORD) == 0;
+        return ptrIndex >= this.pointerCount || this.segment.getBuffer().getLong((this.pointers + ptrIndex) * Constants.BYTES_PER_WORD) == 0;
     }
 
     protected final void _clearPointerField(int ptrIndex) {
         int pointer = this.pointers + ptrIndex;
         WireHelpers.zeroObject(this.segment, pointer);
-        this.segment.buffer.putLong(pointer * 8, 0L);
+        this.segment.getBuffer().putLong(pointer * 8, 0L);
     }
 
     protected final <T> T _getPointerField(FromPointerBuilder<T> factory, int index) {
@@ -181,12 +181,12 @@ public class StructBuilder {
     }
 
     protected final <T> T _getPointerField(FromPointerBuilderRefDefault<T> factory, int index,
-                                           SegmentReader defaultSegment, int defaultOffset) {
+            SegmentDataContainer defaultSegment, int defaultOffset) {
         return factory.fromPointerBuilderRefDefault(this.segment, this.pointers + index, defaultSegment, defaultOffset);
     }
 
     protected final <T> T _getPointerField(FromPointerBuilderBlobDefault<T> factory, int index,
-                                           java.nio.ByteBuffer defaultBuffer, int defaultOffset, int defaultSize) {
+            java.nio.ByteBuffer defaultBuffer, int defaultOffset, int defaultSize) {
         return factory.fromPointerBuilderBlobDefault(this.segment, this.pointers + index, defaultBuffer, defaultOffset, defaultSize);
     }
 

--- a/runtime/src/main/java/org/capnproto/StructFactory.java
+++ b/runtime/src/main/java/org/capnproto/StructFactory.java
@@ -28,8 +28,8 @@ public abstract class StructFactory<Builder, Reader extends StructReader>
     SetPointerBuilder<Builder, Reader>,
     FromPointerReaderRefDefault<Reader>,
     StructReader.Factory<Reader> {
-    public final Reader fromPointerReaderRefDefault(SegmentReader segment, int pointer,
-                                                    SegmentReader defaultSegment, int defaultOffset,
+    public final Reader fromPointerReaderRefDefault(SegmentDataContainer segment, int pointer,
+                                                    SegmentDataContainer defaultSegment, int defaultOffset,
                                                     int nestingLimit) {
         return WireHelpers.readStructPointer(this,
                                              segment,
@@ -37,23 +37,23 @@ public abstract class StructFactory<Builder, Reader extends StructReader>
                                              defaultSegment, defaultOffset,
                                              nestingLimit);
     }
-    public final Reader fromPointerReader(SegmentReader segment, int pointer, int nestingLimit) {
+    public final Reader fromPointerReader(SegmentDataContainer segment, int pointer, int nestingLimit) {
         return fromPointerReaderRefDefault(segment, pointer, null, 0, nestingLimit);
     }
-    public final Builder fromPointerBuilderRefDefault(SegmentBuilder segment, int pointer,
-                                                      SegmentReader defaultSegment, int defaultOffset) {
+    public final Builder fromPointerBuilderRefDefault(GenericSegmentBuilder segment, int pointer,
+                                                      SegmentDataContainer defaultSegment, int defaultOffset) {
         return WireHelpers.getWritableStructPointer(this, pointer, segment, this.structSize(),
                                                     defaultSegment, defaultOffset);
     }
-    public final Builder fromPointerBuilder(SegmentBuilder segment, int pointer) {
+    public final Builder fromPointerBuilder(GenericSegmentBuilder segment, int pointer) {
         return WireHelpers.getWritableStructPointer(this, pointer, segment, this.structSize(),
                                                     null, 0);
     }
-    public final Builder initFromPointerBuilder(SegmentBuilder segment, int pointer, int elementCount) {
+    public final Builder initFromPointerBuilder(GenericSegmentBuilder segment, int pointer, int elementCount) {
         return WireHelpers.initStructPointer(this, pointer, segment, this.structSize());
     }
 
-    public final void setPointerBuilder(SegmentBuilder segment, int pointer, Reader value) {
+    public final void setPointerBuilder(GenericSegmentBuilder segment, int pointer, Reader value) {
         WireHelpers.setStructPointer(segment, pointer, value);
     }
 

--- a/runtime/src/main/java/org/capnproto/StructList.java
+++ b/runtime/src/main/java/org/capnproto/StructList.java
@@ -32,7 +32,7 @@ public final class StructList {
             this.factory = factory;
         }
 
-        public final Reader<ElementReader> constructReader(SegmentReader segment,
+        public final Reader<ElementReader> constructReader(SegmentDataContainer segment,
                                                            int ptr,
                                                            int elementCount, int step,
                                                            int structDataSize, short structPointerCount,
@@ -41,15 +41,15 @@ public final class StructList {
                                              segment, ptr, elementCount, step, structDataSize, structPointerCount, nestingLimit);
         }
 
-        public final Builder<ElementBuilder> constructBuilder(SegmentBuilder segment,
+        public final Builder<ElementBuilder> constructBuilder(GenericSegmentBuilder segment,
                                                               int ptr,
                                                               int elementCount, int step,
                                                               int structDataSize, short structPointerCount) {
             return new Builder<ElementBuilder> (factory, segment, ptr, elementCount, step, structDataSize, structPointerCount);
         }
 
-        public final Builder<ElementBuilder> fromPointerBuilderRefDefault(SegmentBuilder segment, int pointer,
-                                                                          SegmentReader defaultSegment, int defaultOffset) {
+        public final Builder<ElementBuilder> fromPointerBuilderRefDefault(GenericSegmentBuilder segment, int pointer,
+                                                                          SegmentDataContainer defaultSegment, int defaultOffset) {
             return WireHelpers.getWritableStructListPointer(this,
                                                             pointer,
                                                             segment,
@@ -59,7 +59,7 @@ public final class StructList {
         }
 
         @Override
-        public final Builder<ElementBuilder> fromPointerBuilder(SegmentBuilder segment, int pointer) {
+        public final Builder<ElementBuilder> fromPointerBuilder(GenericSegmentBuilder segment, int pointer) {
                      return WireHelpers.getWritableStructListPointer(this,
                                                                      pointer,
                                                                      segment,
@@ -68,7 +68,7 @@ public final class StructList {
         }
 
         @Override
-        public final Builder<ElementBuilder> initFromPointerBuilder(SegmentBuilder segment, int pointer,
+        public final Builder<ElementBuilder> initFromPointerBuilder(GenericSegmentBuilder segment, int pointer,
                                                                     int elementCount) {
             return WireHelpers.initStructListPointer(this, pointer, segment, elementCount, factory.structSize());
         }
@@ -78,7 +78,7 @@ public final class StructList {
         public final StructReader.Factory<T> factory;
 
         public Reader(StructReader.Factory<T> factory,
-                      SegmentReader segment,
+                      SegmentDataContainer segment,
                       int ptr,
                       int elementCount, int step,
                       int structDataSize, short structPointerCount,
@@ -119,7 +119,7 @@ public final class StructList {
         public final StructBuilder.Factory<T> factory;
 
         public Builder(StructBuilder.Factory<T> factory,
-                       SegmentBuilder segment, int ptr,
+                       GenericSegmentBuilder segment, int ptr,
                        int elementCount, int step,
                        int structDataSize, short structPointerCount){
             super(segment, ptr, elementCount, step, structDataSize, structPointerCount);

--- a/runtime/src/main/java/org/capnproto/Text.java
+++ b/runtime/src/main/java/org/capnproto/Text.java
@@ -18,52 +18,54 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
 package org.capnproto;
 
 import java.nio.ByteBuffer;
 
 public final class Text {
+
     public static final class Factory implements
-                                      FromPointerReaderBlobDefault<Reader>,
-                                      FromPointerBuilderBlobDefault<Builder>,
-                                      PointerFactory<Builder, Reader>,
-                                      SetPointerBuilder<Builder, Reader> {
-        public final Reader fromPointerReaderBlobDefault(SegmentReader segment, int pointer, java.nio.ByteBuffer defaultBuffer,
-                                                   int defaultOffset, int defaultSize) {
+            FromPointerReaderBlobDefault<Reader>,
+            FromPointerBuilderBlobDefault<Builder>,
+            PointerFactory<Builder, Reader>,
+            SetPointerBuilder<Builder, Reader> {
+
+        public final Reader fromPointerReaderBlobDefault(SegmentDataContainer segment, int pointer, java.nio.ByteBuffer defaultBuffer,
+                int defaultOffset, int defaultSize) {
             return WireHelpers.readTextPointer(segment, pointer, defaultBuffer, defaultOffset, defaultSize);
         }
 
-        public final Reader fromPointerReader(SegmentReader segment, int pointer, int nestingLimit) {
+        public final Reader fromPointerReader(SegmentDataContainer segment, int pointer, int nestingLimit) {
             return WireHelpers.readTextPointer(segment, pointer, null, 0, 0);
         }
 
-        public final Builder fromPointerBuilderBlobDefault(SegmentBuilder segment, int pointer,
-                                                     java.nio.ByteBuffer defaultBuffer, int defaultOffset, int defaultSize) {
+        public final Builder fromPointerBuilderBlobDefault(GenericSegmentBuilder segment, int pointer,
+                java.nio.ByteBuffer defaultBuffer, int defaultOffset, int defaultSize) {
             return WireHelpers.getWritableTextPointer(pointer,
-                                                      segment,
-                                                      defaultBuffer,
-                                                      defaultOffset,
-                                                      defaultSize);
+                    segment,
+                    defaultBuffer,
+                    defaultOffset,
+                    defaultSize);
         }
 
-        public final Builder fromPointerBuilder(SegmentBuilder segment, int pointer) {
+        public final Builder fromPointerBuilder(GenericSegmentBuilder segment, int pointer) {
             return WireHelpers.getWritableTextPointer(pointer,
-                                                      segment,
-                                                      null, 0, 0);
+                    segment,
+                    null, 0, 0);
         }
 
-        public final Builder initFromPointerBuilder(SegmentBuilder segment, int pointer, int size) {
+        public final Builder initFromPointerBuilder(GenericSegmentBuilder segment, int pointer, int size) {
             return WireHelpers.initTextPointer(pointer, segment, size);
         }
 
-        public final void setPointerBuilder(SegmentBuilder segment, int pointer, Reader value) {
+        public final void setPointerBuilder(GenericSegmentBuilder segment, int pointer, Reader value) {
             WireHelpers.setTextPointer(pointer, segment, value);
         }
     }
     public static final Factory factory = new Factory();
 
     public static final class Reader {
+
         public final ByteBuffer buffer;
         public final int offset; // in bytes
         public final int size; // in bytes, not including NUL terminator
@@ -122,6 +124,7 @@ public final class Text {
     }
 
     public static final class Builder {
+
         public final ByteBuffer buffer;
         public final int offset; // in bytes
         public final int size; // in bytes
@@ -159,6 +162,22 @@ public final class Text {
             } catch (java.io.UnsupportedEncodingException e) {
                 throw new Error("UTF-8 is unsupported");
             }
+        }
+
+        void copy(Reader value) {
+            ByteBuffer slice = value.buffer.duplicate();
+            slice.position(value.offset);
+            slice.limit(value.offset + value.size);
+            buffer.position(offset);
+            buffer.put(slice);
+        }
+
+        void put(int i, byte get) {
+            buffer.put(i, get);
+        }
+
+        ByteBuffer getBuffer() {
+            return buffer;
         }
 
     }

--- a/runtime/src/main/java/org/capnproto/TextList.java
+++ b/runtime/src/main/java/org/capnproto/TextList.java
@@ -24,7 +24,7 @@ package org.capnproto;
 public final class TextList {
     public static final class Factory extends ListFactory<Builder, Reader> {
         Factory() {super (ElementSize.POINTER); }
-        public final Reader constructReader(SegmentReader segment,
+        public final Reader constructReader(SegmentDataContainer segment,
                                             int ptr,
                                             int elementCount, int step,
                                             int structDataSize, short structPointerCount,
@@ -32,7 +32,7 @@ public final class TextList {
             return new Reader(segment, ptr, elementCount, step, structDataSize, structPointerCount, nestingLimit);
         }
 
-        public final Builder constructBuilder(SegmentBuilder segment,
+        public final Builder constructBuilder(GenericSegmentBuilder segment,
                                                 int ptr,
                                                 int elementCount, int step,
                                                 int structDataSize, short structPointerCount) {
@@ -42,7 +42,7 @@ public final class TextList {
     public static final Factory factory = new Factory();
 
     public static final class Reader extends ListReader implements Iterable<Text.Reader> {
-        public Reader(SegmentReader segment,
+        public Reader(SegmentDataContainer segment,
                       int ptr,
                       int elementCount, int step,
                       int structDataSize, short structPointerCount,
@@ -79,7 +79,7 @@ public final class TextList {
     }
 
     public static final class Builder extends ListBuilder implements Iterable<Text.Builder> {
-        public Builder(SegmentBuilder segment, int ptr,
+        public Builder(GenericSegmentBuilder segment, int ptr,
                        int elementCount, int step,
                        int structDataSize, short structPointerCount){
             super(segment, ptr, elementCount, step, structDataSize, structPointerCount);

--- a/runtime/src/test/scala/org/capnproto/ArrayInputStreamSuite.scala
+++ b/runtime/src/test/scala/org/capnproto/ArrayInputStreamSuite.scala
@@ -29,6 +29,17 @@ class ArrayInputStreamSuite extends FunSuite {
   test("EmptyArray") {
     val stream = new ArrayInputStream(ByteBuffer.allocate(0))
     val dst = ByteBuffer.allocate(10)
-    stream.read(dst) should equal (0)
+
+    // read() should return -1 at the end of the stream
+    // https://docs.oracle.com/javase/7/docs/api/java/nio/channels/ReadableByteChannel.html
+    stream.read(dst) should equal (-1)
+  }
+
+  test("Request more bytes than are present") {
+    val oneByte: Array[Byte] = Array(42)
+    val stream = new ArrayInputStream(ByteBuffer.wrap(oneByte))
+    val dst = ByteBuffer.allocate(10)
+    stream.read(dst) should equal (1)
+    stream.read(dst) should equal (-1) // end of stream
   }
 }

--- a/runtime/src/test/scala/org/capnproto/ArrayInputStreamSuite.scala
+++ b/runtime/src/test/scala/org/capnproto/ArrayInputStreamSuite.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2014 Sandstorm Development Group, Inc. and contributors
+// Copyright (c) 2018 Sandstorm Development Group, Inc. and contributors
 // Licensed under the MIT License:
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,41 +19,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package org.capnproto;
+package org.capnproto
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.ReadableByteChannel;
+import java.nio.ByteBuffer
+import org.scalatest.FunSuite
+import org.scalatest.Matchers._
 
-public final class ArrayInputStream implements BufferedInputStream {
-
-    public final ByteBuffer buf;
-
-    public ArrayInputStream(ByteBuffer buf) {
-        this.buf = buf.asReadOnlyBuffer();
-    }
-
-    public final int read(ByteBuffer dst) throws IOException {
-        int available = this.buf.remaining();
-        int size = java.lang.Math.min(dst.remaining(), available);
-
-        ByteBuffer slice = this.buf.slice();
-        slice.limit(size);
-        dst.put(slice);
-
-        this.buf.position(this.buf.position() + size);
-        return size;
-    }
-
-    public final ByteBuffer getReadBuffer() {
-        return this.buf;
-    }
-
-    public final void close() throws IOException {
-        return;
-    }
-
-    public final boolean isOpen() {
-        return true;
-    }
+class ArrayInputStreamSuite extends FunSuite {
+  test("EmptyArray") {
+    val stream = new ArrayInputStream(ByteBuffer.allocate(0))
+    val dst = ByteBuffer.allocate(10)
+    stream.read(dst) should equal (0)
+  }
 }

--- a/runtime/src/test/scala/org/capnproto/LayoutSuite.scala
+++ b/runtime/src/test/scala/org/capnproto/LayoutSuite.scala
@@ -27,7 +27,7 @@ import org.scalatest.FunSuite
 class LayoutSuite extends FunSuite {
 
   class BareStructReader extends StructReader.Factory[StructReader] {
-    def constructReader(segment: org.capnproto.SegmentReader, data: Int, pointers: Int,
+    def constructReader(segment: org.capnproto.SegmentDataContainer, data: Int, pointers: Int,
                         dataSize: Int, pointerCount: Short, nestingLimit:Int) : StructReader = {
       new StructReader(segment,data,pointers,dataSize,pointerCount,nestingLimit)
     }
@@ -121,7 +121,7 @@ class LayoutSuite extends FunSuite {
 
   class BareStructBuilder(val structSize : StructSize) extends StructBuilder.Factory[StructBuilder] {
 
-    def constructBuilder(segment: org.capnproto.SegmentBuilder, data: Int, pointers: Int,
+    def constructBuilder(segment: org.capnproto.GenericSegmentBuilder, data: Int, pointers: Int,
                           dataSize: Int, pointerCount: Short) : StructBuilder = {
       new StructBuilder(segment,data,pointers,dataSize,pointerCount)
     }

--- a/runtime/src/test/scala/org/capnproto/SerializeSuite.scala
+++ b/runtime/src/test/scala/org/capnproto/SerializeSuite.scala
@@ -32,11 +32,11 @@ class SerializeSuite extends FunSuite {
    * @param exampleBytes byte array containing `segmentCount` segments; segment `i` contains `i` words each set to `i`
    */
   def expectSerializesTo(exampleSegmentCount: Int, exampleBytes: Array[Byte]): Unit = {
-    def checkSegmentContents(arena: ReaderArena): Unit = {
-      arena.segments should have length exampleSegmentCount
+    def checkSegmentContents(arena: AllocatedArena): Unit = {
+      arena.getSegments() should have length exampleSegmentCount
       for (i <- 0 until exampleSegmentCount) {
-        val segment = arena.segments.get(i)
-        val segmentWords = segment.buffer.asLongBuffer()
+        val segment = arena.getSegments().get(i)
+        val segmentWords = segment.getBuffer().asLongBuffer()
 
         segmentWords.capacity should equal (i)
         segmentWords.rewind()


### PR DESCRIPTION
The idea of this change is to open up MessageBuilder to allow an external custom Arena (implementing AllocatingArena) that can also introduce external custom SegmentBuilder (implementing GenericSegmentBuilder).
The interfaces are easy to implement and allow to inject a fine tuned memory management for users that need to differ between heap or direct memory or even have netty ByteBufs managing the ByteBuffers used for serialization.

I had to change some access methods, as the members of SegmentReader and Builder can only be represented as methods in the interfaces. so maybe external code that accessed this memory directly might break, but is easy fixable by using getBuffer()