### PR TITLE
support custom allocators for builder segments

### DIFF
--- a/runtime/src/main/java/org/capnproto/Allocator.java
+++ b/runtime/src/main/java/org/capnproto/Allocator.java
@@ -1,0 +1,13 @@
+package org.capnproto;
+
+/**
+ * An object that allocates memory for a Cap'n Proto message as it is being built.
+ */
+interface Allocator {
+    /**
+     * Allocates a ByteBuffer to be used as a segment in a message. The returned
+     * buffer must contain at least `minimumSize` bytes, all of which MUST be
+     * set to zero.
+     */
+   public java.nio.ByteBuffer allocateSegment(int minimumSize);
+}

--- a/runtime/src/main/java/org/capnproto/BuilderArena.java
+++ b/runtime/src/main/java/org/capnproto/BuilderArena.java
@@ -52,6 +52,18 @@ public final class BuilderArena implements Arena {
         this.allocator = allocator;
     }
 
+    public BuilderArena(Allocator allocator, ByteBuffer firstSegment) {
+        this.segments = new ArrayList<SegmentBuilder>();
+        SegmentBuilder newSegment = new SegmentBuilder(
+            firstSegment,
+            this);
+        newSegment.buffer.order(ByteOrder.LITTLE_ENDIAN);
+        newSegment.id = 0;
+        this.segments.add(newSegment);
+
+        this.allocator = allocator;
+    }
+
     @Override
     public final SegmentReader tryGetSegment(int id) {
         return this.segments.get(id);

--- a/runtime/src/main/java/org/capnproto/DefaultAllocator.java
+++ b/runtime/src/main/java/org/capnproto/DefaultAllocator.java
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer;
 
 import org.capnproto.BuilderArena.AllocationStrategy;
 
-class DefaultAllocator implements Allocator {
+public class DefaultAllocator implements Allocator {
 
     // (minimum) number of bytes in the next allocation
     private int nextSize = BuilderArena.SUGGESTED_FIRST_SEGMENT_WORDS;
@@ -17,6 +17,8 @@ class DefaultAllocator implements Allocator {
 
     public AllocationStrategy allocationStrategy =
         AllocationStrategy.GROW_HEURISTICALLY;
+
+    public DefaultAllocator() {}
 
     public DefaultAllocator(AllocationStrategy allocationStrategy) {
         this.allocationStrategy = allocationStrategy;

--- a/runtime/src/main/java/org/capnproto/DefaultAllocator.java
+++ b/runtime/src/main/java/org/capnproto/DefaultAllocator.java
@@ -1,0 +1,65 @@
+package org.capnproto;
+
+import java.nio.ByteBuffer;
+
+import org.capnproto.BuilderArena.AllocationStrategy;
+
+class DefaultAllocator implements Allocator {
+
+    // (minimum) number of bytes in the next allocation
+    private int nextSize = 0;
+
+    public enum ByteBufferAllocationStyle {
+        REGULAR,
+        DIRECT
+    }
+    public ByteBufferAllocationStyle allocationStyle = ByteBufferAllocationStyle.REGULAR;
+
+    public AllocationStrategy allocationStrategy =
+        AllocationStrategy.GROW_HEURISTICALLY;
+
+    public DefaultAllocator(AllocationStrategy allocationStrategy) {
+        this.allocationStrategy = allocationStrategy;
+    }
+
+    public DefaultAllocator(ByteBufferAllocationStyle style) {
+        this.allocationStyle = style;
+    }
+
+    public DefaultAllocator(AllocationStrategy allocationStrategy,
+                            ByteBufferAllocationStyle style) {
+        this.allocationStrategy = allocationStrategy;
+        this.allocationStyle = style;
+    }
+
+    public void setNextAllocationSizeBytes(int nextSize) {
+        this.nextSize = nextSize;
+    }
+
+    @Override
+    public java.nio.ByteBuffer allocateSegment(int minimumSize) {
+        int size = Math.max(minimumSize, this.nextSize);
+        ByteBuffer result = null;
+        switch (allocationStyle) {
+          case REGULAR:
+            result = ByteBuffer.allocate(size);
+            break;
+          case DIRECT:
+            result = ByteBuffer.allocateDirect(size);
+        }
+
+        switch (this.allocationStrategy) {
+            case GROW_HEURISTICALLY:
+                this.nextSize += size;
+                break;
+            case FIXED_SIZE:
+                if (nextSize == 0) {
+                    nextSize = size;
+                }
+                break;
+        }
+
+        this.nextSize += size;
+        return result;
+    }
+}

--- a/runtime/src/main/java/org/capnproto/DefaultAllocator.java
+++ b/runtime/src/main/java/org/capnproto/DefaultAllocator.java
@@ -7,7 +7,7 @@ import org.capnproto.BuilderArena.AllocationStrategy;
 class DefaultAllocator implements Allocator {
 
     // (minimum) number of bytes in the next allocation
-    private int nextSize = 0;
+    private int nextSize = BuilderArena.SUGGESTED_FIRST_SEGMENT_WORDS;
 
     public enum ByteBufferAllocationStyle {
         REGULAR,
@@ -53,9 +53,6 @@ class DefaultAllocator implements Allocator {
                 this.nextSize += size;
                 break;
             case FIXED_SIZE:
-                if (nextSize == 0) {
-                    nextSize = size;
-                }
                 break;
         }
 

--- a/runtime/src/main/java/org/capnproto/MessageBuilder.java
+++ b/runtime/src/main/java/org/capnproto/MessageBuilder.java
@@ -40,8 +40,24 @@ public final class MessageBuilder {
                                       allocationStrategy);
     }
 
+    /**
+     * Constructs a new MessageBuilder from an Allocator.
+     */
     public MessageBuilder(Allocator allocator) {
         this.arena = new BuilderArena(allocator);
+    }
+
+    /**
+     * Constructs a new MessageBuilder from an Allocator and a given first segment buffer.
+     * This is useful for reusing the first segment buffer between messages, to avoid
+     * repeated allocations.
+     *
+     * You MUST ensure that firstSegment contains only zeroes before calling this method.
+     * If you are reusing firstSegment from another message, then it suffices to call
+     * clearFirstSegment() on that message.
+     */
+    public MessageBuilder(Allocator allocator, java.nio.ByteBuffer firstSegment) {
+        this.arena = new BuilderArena(allocator, firstSegment);
     }
 
     private AnyPointer.Builder getRootInternal() {
@@ -77,5 +93,16 @@ public final class MessageBuilder {
 
     public final java.nio.ByteBuffer[] getSegmentsForOutput() {
         return this.arena.getSegmentsForOutput();
+    }
+
+    /**
+     * Sets the first segment buffer to contain all zeros so that it can be reused in
+     * another message. (See the MessageBuilder(Allocator, ByteBuffer) constructor above.)
+     *
+     * After calling this method, the message will be corrupted. Therefore, you need to make
+     * sure to write the message (via getSegmentsForOutput()) before calling this.
+     */
+    public final void clearFirstSegment() {
+        this.arena.segments.get(0).clear();
     }
 }

--- a/runtime/src/main/java/org/capnproto/MessageBuilder.java
+++ b/runtime/src/main/java/org/capnproto/MessageBuilder.java
@@ -40,7 +40,14 @@ public final class MessageBuilder {
                                       allocationStrategy);
     }
 
+    public MessageBuilder(Allocator allocator) {
+        this.arena = new BuilderArena(allocator);
+    }
+
     private AnyPointer.Builder getRootInternal() {
+        if (this.arena.segments.isEmpty()) {
+            this.arena.allocate(1);
+        }
         SegmentBuilder rootSegment = this.arena.segments.get(0);
         if (rootSegment.currentSize() == 0) {
             int location = rootSegment.allocate(1);

--- a/runtime/src/main/java/org/capnproto/MessageBuilder.java
+++ b/runtime/src/main/java/org/capnproto/MessageBuilder.java
@@ -60,6 +60,18 @@ public final class MessageBuilder {
         this.arena = new BuilderArena(allocator, firstSegment);
     }
 
+    /**
+     * Like the previous constructor, but uses a DefaultAllocator.
+     *
+     * You MUST ensure that firstSegment contains only zeroes before calling this method.
+     * If you are reusing firstSegment from another message, then it suffices to call
+     * clearFirstSegment() on that message.
+     */
+    public MessageBuilder(java.nio.ByteBuffer firstSegment) {
+        this.arena = new BuilderArena(new DefaultAllocator(), firstSegment);
+    }
+
+
     private AnyPointer.Builder getRootInternal() {
         if (this.arena.segments.isEmpty()) {
             this.arena.allocate(1);

--- a/runtime/src/main/java/org/capnproto/SegmentBuilder.java
+++ b/runtime/src/main/java/org/capnproto/SegmentBuilder.java
@@ -72,4 +72,11 @@ public final class SegmentBuilder extends SegmentReader {
     public final void put(int index, long value) {
         buffer.putLong(index * Constants.BYTES_PER_WORD, value);
     }
+
+    public final void clear() {
+        for (int ii = 0; ii <  this.pos; ++ii) {
+            this.put(ii, 0);
+        }
+        this.pos = 0;
+    }
 }


### PR DESCRIPTION
An implementation of https://github.com/capnproto/capnproto-java/pull/71#issuecomment-472654158

This allows client code to supply custom allocators via the new `org.capnproto.Allocator` interface.
A concrete `DefaultAllocator` implementation provides all the functionality previously supported.
As a convenience, `DefaultAllocator` includes opt-in support for direct ByteBuffers.