### PR TITLE
build fix. use c++14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: xenial
 sudo: false
 language: java
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 sudo: false
 language: java
 env:
@@ -9,8 +9,8 @@ env:
 addons:
   apt:
     packages:
-      - gcc
-      - g++
+      - gcc-6
+      - g++-6
 install:
   - curl -O https://capnproto.org/capnproto-c++-0.5.3.tar.gz
   - tar zxf capnproto-c++-0.5.3.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CAPNP_CXX_FLAGS=-I $(CAPNP_PREFIX)/include -L $(CAPNP_PREFIX)/lib -lkj -lcapnp
 endif
 
 CXX=g++
-CXX_FLAGS=-std=c++11 $(CAPNP_CXX_FLAGS)
+CXX_FLAGS=-std=c++14 $(CAPNP_CXX_FLAGS)
 
 CAPNPC_JAVA_SOURCES=compiler/src/main/cpp/capnpc-java.c++
 
@@ -25,7 +25,7 @@ capnpc-java : $(CAPNPC_JAVA_SOURCES)
 
 MINGW_LIBS=~/src/capnproto/c++/build-mingw/.libs/libcapnp.a ~/src/capnproto/c++/build-mingw/.libs/libkj.a
 MINGW_CXX=i686-w64-mingw32-g++
-MINGW_FLAGS=-O2 -DNDEBUG -I/usr/local/include -std=c++11 -static -static-libgcc -static-libstdc++
+MINGW_FLAGS=-O2 -DNDEBUG -I/usr/local/include -std=c++14 -static -static-libgcc -static-libstdc++
 capnpc-java.exe : $(CAPNPC_JAVA_SOURCES)
 	$(MINGW_CXX) $(MINGW_FLAGS) $(CAPNPC_JAVA_SOURCES) $(MINGW_LIBS) -o capnpc-java.exe
 


### PR DESCRIPTION
Fixes this:
```
/usr/include/kj/common.h:36:4: error: #error "This code requires C++14. Either your compiler does not support it or it is not enabled."
   #error "This code requires C++14. Either your compiler does not support it or it is not enabled."

```