### PR TITLE
Bump the C++ standard flag up to `-c++14`

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.9)
 
 find_package(PkgConfig REQUIRED)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CAPNPC_JAVA_SOURCES ../compiler/src/main/cpp/capnpc-java.c++)
 
 if(CAPNP_PKG_PATH)


### PR DESCRIPTION
… the current version of `kj` requires C++14 at a minimum; this change keeps the build of `capnpc-java` from erroring out.