### PR TITLE
Throw exception on 0-byte read.

### DIFF
--- a/runtime/src/main/java/org/capnproto/Serialize.java
+++ b/runtime/src/main/java/org/capnproto/Serialize.java
@@ -42,8 +42,9 @@ public final class Serialize {
             int r = bc.read(buffer);
             if (r < 0) {
                 throw new IOException("premature EOF");
+            } else if (r == 0) {
+                throw new IOException("Read zero bytes. Is the channel in non-blocking mode?");
             }
-            // TODO check for r == 0 ?.
         }
     }
 


### PR DESCRIPTION
According to the [docs](https://docs.oracle.com/javase/8/docs/api/java/nio/channels/ReadableByteChannel.html):

> It is guaranteed, however, that if a channel is in blocking mode and there is at least one byte remaining in the buffer then this method will block until at least one byte is read.

Previously we would busy-wait in this case. Throwing an exception is better. The caller should be informed that they probably should put the socket in blocking mode.