### PR TITLE
Offer option to disable traversalLimitInWords

### DIFF
--- a/runtime/src/main/java/org/capnproto/ReaderArena.java
+++ b/runtime/src/main/java/org/capnproto/ReaderArena.java
@@ -45,11 +45,13 @@ public final class ReaderArena implements Arena {
     }
 
     @Override
-    public final void checkReadLimit(int numBytes) {
-        if (numBytes > limit) {
+    public final void checkReadLimit(int numWords) {
+        if (limit == -1) {
+            return;
+        } else if (numWords > limit) {
             throw new DecodeException("Read limit exceeded.");
         } else {
-            limit -= numBytes;
+            limit -= numWords;
         }
     }
 }

--- a/runtime/src/main/java/org/capnproto/Serialize.java
+++ b/runtime/src/main/java/org/capnproto/Serialize.java
@@ -145,7 +145,7 @@ public final class Serialize {
         }
         bb.position(segmentBase + totalWords * Constants.BYTES_PER_WORD);
 
-        if (totalWords > options.traversalLimitInWords) {
+        if (options.traversalLimitInWords != -1 && totalWords > options.traversalLimitInWords) {
             throw new DecodeException("Message size exceeds traversal limit.");
         }
 


### PR DESCRIPTION
Use case: large trusted input data file, mapped in memory by
MappedByteBuffer, which is often re-queried so a sensible
limit cannot be set.