### PR TITLE
Makefile: Enable overriding `pkg-config`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-CAPNP_CXX_FLAGS=$(shell pkg-config capnp --cflags --libs)
+PKG_CONFIG ?= pkg-config
+CAPNP_CXX_FLAGS=$(shell $(PKG_CONFIG) capnp --cflags --libs)
 
 ifeq ($(CAPNP_CXX_FLAGS),)
 $(warning "Warning: pkg-config failed to find compilation configuration for capnp.")


### PR DESCRIPTION
Sometimes there's a need to precise which `pkg-config` is to be used.
Now `pkg-config`'s name or path can be overridden with `PKG_CONFIG`.

Fixes #106.