### PR TITLE
Makefile: Use non-local prefix per default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CAPNP_PREFIX=$(shell dirname $(shell which capnp))/..
 CAPNP_CXX_FLAGS=-I $(CAPNP_PREFIX)/include -L $(CAPNP_PREFIX)/lib -lkj -lcapnp
 endif
 
-PREFIX ?= /usr/local
+PREFIX ?= /usr
 
 CXX ?= g++
 CXX_FLAGS=-std=c++14 $(CAPNP_CXX_FLAGS)


### PR DESCRIPTION
This allows the ebuild for Gentoo use they default implementations of the `src_install()` function.