### PR TITLE
Makefile respect cflags and ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean :
 	rm -f capnpc-java capnpc-java.exe
 
 capnpc-java : $(CAPNPC_JAVA_SOURCES)
-	$(CXX) $(CAPNPC_JAVA_SOURCES) $(CXX_FLAGS) -o capnpc-java
+	$(CXX) $(CAPNPC_JAVA_SOURCES) $(CXX_FLAGS) $(CFLAGS) $(LDFLAGS) -o capnpc-java
 
 install:
 	mkdir -p ${PREFIX}/bin


### PR DESCRIPTION
Gentoo users expect that they can pass custom CFLAGS and LDFLAGS if they want, and that those are respected.