### PR TITLE
#122 Add bound checks for struct size (+ fix bounds check implementation)

### DIFF
--- a/runtime/src/main/java/org/capnproto/SegmentReader.java
+++ b/runtime/src/main/java/org/capnproto/SegmentReader.java
@@ -44,6 +44,6 @@ public class SegmentReader {
     public final boolean in_bounds(int start, int size) {
         if (start < 0 || size < 0) return false;
         long sizeInWords = size * Constants.BYTES_PER_WORD;
-        return (long) start + sizeInWords < (long) this.buffer.capacity();
+        return (long) start + sizeInWords <= (long) this.buffer.capacity();
     }
 }

--- a/runtime/src/main/java/org/capnproto/WireHelpers.java
+++ b/runtime/src/main/java/org/capnproto/WireHelpers.java
@@ -918,19 +918,24 @@ final class WireHelpers {
         int refTarget = WirePointer.target(refOffset, ref);
         FollowFarsResult resolved = followFars(ref, refTarget, segment);
 
-        int dataSizeWords = StructPointer.dataSize(resolved.ref);
-
         if (WirePointer.kind(resolved.ref) != WirePointer.STRUCT) {
             throw new DecodeException("Message contains non-struct pointer where struct pointer was expected.");
         }
 
-        resolved.segment.arena.checkReadLimit(StructPointer.wordSize(resolved.ref));
+        int dataSizeWords = StructPointer.dataSize(resolved.ref);
+        int ptrCount = StructPointer.ptrCount(resolved.ref);
+        int wordSize = dataSizeWords + ptrCount;
+
+        resolved.segment.arena.checkReadLimit(wordSize);
+        if (!bounds_check(resolved.segment, resolved.ptr, wordSize)) {
+            throw new DecodeException("Message contains out-of-bounds struct pointer");
+        }
 
         return factory.constructReader(resolved.segment,
                                        resolved.ptr * Constants.BYTES_PER_WORD,
                                        (resolved.ptr + dataSizeWords),
                                        dataSizeWords * Constants.BITS_PER_WORD,
-                                       (short)StructPointer.ptrCount(resolved.ref),
+                                       (short) ptrCount,
                                        nestingLimit - 1);
 
     }

--- a/runtime/src/test/java/org/capnproto/LayoutTest.java
+++ b/runtime/src/test/java/org/capnproto/LayoutTest.java
@@ -63,6 +63,29 @@ public class LayoutTest {
         Assert.assertEquals(reader._getBooleanField(64), false);
     }
 
+    /**
+     * @see <a href="https://github.com/capnproto/capnproto-java/issues/122">#122</a>
+     */
+    @Test(expected = DecodeException.class)
+    public void readStructPointerShouldThrowDecodeExceptionOnOutOfBoundsStructPointer() {
+        byte[] brokenMSG = new byte[]{
+                0x00, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, //declare word size of 7, with payload of only 6 words
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        };
+
+        ByteBuffer buffer = ByteBuffer.wrap(brokenMSG);
+        buffer.order(ByteOrder.LITTLE_ENDIAN);
+
+        ReaderArena arena = new ReaderArena(new ByteBuffer[]{ buffer }, 0x7fffffffffffffffL);
+
+        StructReader reader = WireHelpers.readStructPointer(new BareStructReader(), arena.tryGetSegment(0), 0, null, 0, 0x7fffffff);
+    }
+
     private class BareStructBuilder implements StructBuilder.Factory<StructBuilder> {
         private StructSize structSize;
 


### PR DESCRIPTION
This PR Fixes #122 by adding bounds check to `struct` parsing code..

Also, previous bounds check implementation used wrong comparison sign for comparing the declared size with the capacity of a buffer, so this is now fixed as well.