### PR TITLE
Fix various cases of integer overflow during multiplication

### DIFF
--- a/runtime/src/main/java/org/capnproto/ListBuilder.java
+++ b/runtime/src/main/java/org/capnproto/ListBuilder.java
@@ -81,7 +81,7 @@ public class ListBuilder {
     }
 
     protected void _setBooleanElement(int index, boolean value) {
-        long bitOffset = index * this.step;
+        long bitOffset = (long) index * this.step;
         byte bitnum = (byte)(bitOffset % 8);
         int position = (int)(this.ptr + (bitOffset / 8));
         byte oldValue = this.segment.buffer.get(position);

--- a/runtime/src/main/java/org/capnproto/SegmentReader.java
+++ b/runtime/src/main/java/org/capnproto/SegmentReader.java
@@ -39,11 +39,13 @@ public class SegmentReader {
         return buffer.getLong(index * Constants.BYTES_PER_WORD);
     }
 
-    // Verify that the `size`-long (in words) range starting at word index
-    // `start` is within bounds.
-    public final boolean in_bounds(int start, int size) {
+    /**
+     * Verify that the `size`-long (in words) range starting at word index
+     * `start` is within bounds.
+     */
+    public final boolean isInBounds(int start, int size) {
         if (start < 0 || size < 0) return false;
-        long sizeInWords = size * Constants.BYTES_PER_WORD;
-        return (long) start + sizeInWords <= (long) this.buffer.capacity();
+        long sizeInWords = (long) size * Constants.BYTES_PER_WORD;
+        return start + sizeInWords <= this.buffer.capacity();
     }
 }

--- a/runtime/src/main/java/org/capnproto/Serialize.java
+++ b/runtime/src/main/java/org/capnproto/Serialize.java
@@ -176,15 +176,18 @@ public final class Serialize {
     }
 
     public static long computeSerializedSizeInWords(MessageBuilder message) {
-        final ByteBuffer[] segments = message.getSegmentsForOutput();
+        return computeSerializedSizeInWords(message.getSegmentsForOutput());
+    }
 
-        // From the capnproto documentation:
+    //VisibleForTesting
+    static long computeSerializedSizeInWords(ByteBuffer[] segments) {
+        // From the capnproto documentation (https://capnproto.org/encoding.html#serialization-over-a-stream):
         // "When transmitting over a stream, the following should be sent..."
         long bytes = 0;
         // "(4 bytes) The number of segments, minus one..."
         bytes += 4;
         // "(N * 4 bytes) The size of each segment, in words."
-        bytes += segments.length * 4;
+        bytes += segments.length * 4L;
         // "(0 or 4 bytes) Padding up to the next word boundary."
         if (bytes % 8 != 0) {
             bytes += 4;
@@ -192,7 +195,7 @@ public final class Serialize {
 
         // The content of each segment, in order.
         for (int i = 0; i < segments.length; ++i) {
-            final ByteBuffer s = segments[i];
+            ByteBuffer s = segments[i];
             bytes += s.limit();
         }
 

--- a/runtime/src/main/java/org/capnproto/WireHelpers.java
+++ b/runtime/src/main/java/org/capnproto/WireHelpers.java
@@ -247,10 +247,10 @@ final class WireHelpers {
             case ElementSize.TWO_BYTES:
             case ElementSize.FOUR_BYTES:
             case ElementSize.EIGHT_BYTES: {
-                memset(segment.buffer, ptr * Constants.BYTES_PER_WORD, (byte)0,
-                       roundBitsUpToWords(
-                           ListPointer.elementCount(tag) *
-                           ElementSize.dataBitsPerElement(ListPointer.elementSize(tag))) * Constants.BYTES_PER_WORD);
+                memset(segment.buffer, ptr * Constants.BYTES_PER_WORD, (byte) 0,
+                        roundBitsUpToWords(
+                                (long) ListPointer.elementCount(tag) *
+                                        ElementSize.dataBitsPerElement(ListPointer.elementSize(tag))) * Constants.BYTES_PER_WORD);
                 break;
             }
             case ElementSize.POINTER: {

--- a/runtime/src/main/java/org/capnproto/WireHelpers.java
+++ b/runtime/src/main/java/org/capnproto/WireHelpers.java
@@ -964,7 +964,7 @@ final class WireHelpers {
     };
 
     static SegmentBuilder setListPointer(SegmentBuilder segment, int refOffset, ListReader value) {
-        int totalSize = roundBitsUpToWords(value.elementCount * value.step);
+        int totalSize = roundBitsUpToWords((long) value.elementCount * value.step);
 
         if (value.step <= Constants.BITS_PER_WORD) {
             //# List of non-structs.

--- a/runtime/src/main/java/org/capnproto/WireHelpers.java
+++ b/runtime/src/main/java/org/capnproto/WireHelpers.java
@@ -43,7 +43,7 @@ final class WireHelpers {
     static boolean bounds_check(SegmentReader segment,
                                 int start,
                                 int size) {
-        return segment == null || segment.in_bounds(start, size);
+        return segment == null || segment.isInBounds(start, size);
     }
 
     static class AllocateResult {

--- a/runtime/src/test/java/org/capnproto/LayoutTest.java
+++ b/runtime/src/test/java/org/capnproto/LayoutTest.java
@@ -7,6 +7,9 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 public class LayoutTest {
+
+    private static final int MAX_NESTING_LIMIT = 0x7fffffff;
+
     private class BareStructReader implements StructReader.Factory<StructReader> {
         @Override
         public StructReader constructReader(SegmentReader segment, int data, int pointers, int dataSize, short pointerCount, int nestingLimit) {
@@ -25,7 +28,7 @@ public class LayoutTest {
 
         ReaderArena arena = new ReaderArena(new ByteBuffer[]{ buffer }, 0x7fffffffffffffffL);
 
-        StructReader reader = WireHelpers.readStructPointer(new BareStructReader(), arena.tryGetSegment(0), 0, null, 0, 0x7fffffff);
+        StructReader reader = WireHelpers.readStructPointer(new BareStructReader(), arena.tryGetSegment(0), 0, null, 0, MAX_NESTING_LIMIT);
 
         Assert.assertEquals(reader._getLongField(0), 0xefcdab8967452301L);
         Assert.assertEquals(reader._getLongField(1), 0L);
@@ -83,7 +86,7 @@ public class LayoutTest {
 
         ReaderArena arena = new ReaderArena(new ByteBuffer[]{ buffer }, 0x7fffffffffffffffL);
 
-        StructReader reader = WireHelpers.readStructPointer(new BareStructReader(), arena.tryGetSegment(0), 0, null, 0, 0x7fffffff);
+        StructReader reader = WireHelpers.readStructPointer(new BareStructReader(), arena.tryGetSegment(0), 0, null, 0, MAX_NESTING_LIMIT);
     }
 
 
@@ -111,7 +114,7 @@ public class LayoutTest {
 
         ReaderArena arena = new ReaderArena(new ByteBuffer[]{buffer}, 0x7fffffffffffffffL);
 
-        ListReader reader = WireHelpers.readListPointer(new BareListReader(), arena.tryGetSegment(0), 0, null, 0, (byte) 0, 0x7fffffff);
+        ListReader reader = WireHelpers.readListPointer(new BareListReader(), arena.tryGetSegment(0), 0, null, 0, (byte) 0, MAX_NESTING_LIMIT);
     }
 
     private class BareStructBuilder implements StructBuilder.Factory<StructBuilder> {

--- a/runtime/src/test/java/org/capnproto/ListBuilderTest.java
+++ b/runtime/src/test/java/org/capnproto/ListBuilderTest.java
@@ -1,0 +1,18 @@
+package org.capnproto;
+
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+public class ListBuilderTest {
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void _setBooleanElementShouldNotOverflowDuringPositionOffsetCalculation() {
+        ByteBuffer buffer = ByteBuffer.allocate(10);
+        BuilderArena builderArena = new BuilderArena(new DefaultAllocator());
+        SegmentBuilder segmentBuilder = new SegmentBuilder(buffer, builderArena);
+        ListBuilder listBuilder = new ListBuilder(segmentBuilder, 0, 0, 2, 0, (short) 0);
+
+        listBuilder._setBooleanElement(Integer.MAX_VALUE, true);
+    }
+}

--- a/runtime/src/test/java/org/capnproto/SegmentReaderTest.java
+++ b/runtime/src/test/java/org/capnproto/SegmentReaderTest.java
@@ -1,0 +1,18 @@
+package org.capnproto;
+
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.hamcrest.CoreMatchers.is;
+
+public class SegmentReaderTest {
+
+    @Test
+    public void in_boundsCalculationShouldNotOverflow() {
+        ByteBuffer byteBuffer = ByteBuffer.allocate(64);
+        SegmentReader segmentReader = new SegmentReader(byteBuffer, null);
+        MatcherAssert.assertThat(segmentReader.isInBounds(0, Integer.MAX_VALUE), is(false));
+    }
+}

--- a/runtime/src/test/java/org/capnproto/SerializeTest.java
+++ b/runtime/src/test/java/org/capnproto/SerializeTest.java
@@ -21,10 +21,15 @@
 
 package org.capnproto;
 
-import java.nio.ByteBuffer;
-
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SerializeTest {
 
@@ -147,4 +152,13 @@ public class SerializeTest {
             java.nio.channels.Channels.newChannel(new java.io.ByteArrayInputStream(input));
         MessageReader message = Serialize.read(channel);
   }
+
+    @Test
+    @Ignore("Ignored by default because the huge array used in the test results in a long execution")
+    public void computeSerializedSizeInWordsShouldNotOverflowOnLargeSegmentCounts() {
+        ByteBuffer dummySegmentBuffer = ByteBuffer.allocate(0);
+        ByteBuffer[] segments = new ByteBuffer[Integer.MAX_VALUE / 2];
+        Arrays.fill(segments, dummySegmentBuffer);
+        assertThat(Serialize.computeSerializedSizeInWords(segments), is((segments.length * 4L + 4) / Constants.BYTES_PER_WORD));
+    }
 }


### PR DESCRIPTION
As the title says.
Multiplying two ints before widening to long can lead to overflow. The widening needs to be explicitly done before the multiplication.

See individual commits and messages for details. Some unit tests present for illustration.