### PR TITLE
Performance-related microcleanup

### DIFF
--- a/runtime/src/main/java/org/capnproto/BuilderArena.java
+++ b/runtime/src/main/java/org/capnproto/BuilderArena.java
@@ -36,7 +36,7 @@ public final class BuilderArena implements Arena {
         AllocationStrategy.GROW_HEURISTICALLY;
 
     public final ArrayList<SegmentBuilder> segments;
-    private Allocator allocator;
+    private final Allocator allocator;
 
     public BuilderArena(int firstSegmentSizeWords, AllocationStrategy allocationStrategy) {
         this.segments = new ArrayList<SegmentBuilder>();

--- a/runtime/src/main/java/org/capnproto/DataList.java
+++ b/runtime/src/main/java/org/capnproto/DataList.java
@@ -54,7 +54,7 @@ public final class DataList {
             return _getPointerElement(Data.factory, index);
         }
 
-        public final class Iterator implements java.util.Iterator<Data.Reader> {
+        public static final class Iterator implements java.util.Iterator<Data.Reader> {
             public Reader list;
             public int idx = 0;
             public Iterator(Reader list) {
@@ -99,7 +99,7 @@ public final class DataList {
                               java.lang.Integer.MAX_VALUE);
         }
 
-        public final class Iterator implements java.util.Iterator<Data.Builder> {
+        public static final class Iterator implements java.util.Iterator<Data.Builder> {
             public Builder list;
             public int idx = 0;
             public Iterator(Builder list) {

--- a/runtime/src/main/java/org/capnproto/PackedOutputStream.java
+++ b/runtime/src/main/java/org/capnproto/PackedOutputStream.java
@@ -111,7 +111,7 @@ public final class PackedOutputStream implements WritableByteChannel {
             out.position(out.position() + bit7 - 1);
             inPtr += 1;
 
-            byte tag = (byte)((bit0 << 0) | (bit1 << 1) | (bit2 << 2) | (bit3 << 3) |
+            byte tag = (byte)((bit0) | (bit1 << 1) | (bit2 << 2) | (bit3 << 3) |
                               (bit4 << 4) | (bit5 << 5) | (bit6 << 6) | (bit7 << 7));
 
             out.put(tagPos, tag);

--- a/runtime/src/main/java/org/capnproto/ReaderArena.java
+++ b/runtime/src/main/java/org/capnproto/ReaderArena.java
@@ -33,7 +33,7 @@ public final class ReaderArena implements Arena {
 
     public ReaderArena(ByteBuffer[] segmentSlices, long traversalLimitInWords) {
         this.limit = traversalLimitInWords;
-        this.segments = new ArrayList<SegmentReader>();
+        this.segments = new ArrayList<>(segmentSlices.length);
         for(int ii = 0; ii < segmentSlices.length; ++ii) {
             this.segments.add(new SegmentReader(segmentSlices[ii], this));
         }

--- a/runtime/src/main/java/org/capnproto/Serialize.java
+++ b/runtime/src/main/java/org/capnproto/Serialize.java
@@ -41,7 +41,7 @@ public final class Serialize {
         return result;
     }
 
-    static int MAX_SEGMENT_WORDS = (1 << 28) - 1;
+    static final int MAX_SEGMENT_WORDS = (1 << 28) - 1;
 
     static ByteBuffer makeByteBufferForWords(int words) throws IOException {
         if (words > MAX_SEGMENT_WORDS) {
@@ -77,10 +77,7 @@ public final class Serialize {
 
         int segmentCount = 1 + rawSegmentCount;
 
-        int segment0Size = 0;
-        if (segmentCount > 0) {
-            segment0Size = firstWord.getInt(4);
-        }
+        int segment0Size = firstWord.getInt(4);
 
         if (segment0Size < 0) {
             throw new DecodeException("segment 0 has more than 2^31 words, which is unsupported");
@@ -89,7 +86,7 @@ public final class Serialize {
         long totalWords = segment0Size;
 
         // in words
-        ArrayList<Integer> moreSizes = new ArrayList<Integer>();
+        ArrayList<Integer> moreSizes = new ArrayList<>(segmentCount -1);
 
         if (segmentCount > 1) {
             ByteBuffer moreSizesRaw = makeByteBuffer(4 * (segmentCount & ~1));
@@ -116,7 +113,6 @@ public final class Serialize {
         fillBuffer(segmentSlices[0], bc);
         segmentSlices[0].rewind();
 
-        int offset = segment0Size;
         for (int ii = 1; ii < segmentCount; ++ii) {
             segmentSlices[ii] = makeByteBufferForWords(moreSizes.get(ii - 1));
             fillBuffer(segmentSlices[ii], bc);

--- a/runtime/src/main/java/org/capnproto/TextList.java
+++ b/runtime/src/main/java/org/capnproto/TextList.java
@@ -54,7 +54,7 @@ public final class TextList {
             return _getPointerElement(Text.factory, index);
         }
 
-        public final class Iterator implements java.util.Iterator<Text.Reader> {
+        public static final class Iterator implements java.util.Iterator<Text.Reader> {
             public Reader list;
             public int idx = 0;
             public Iterator(Reader list) {
@@ -99,7 +99,7 @@ public final class TextList {
                               java.lang.Integer.MAX_VALUE);
         }
 
-        public final class Iterator implements java.util.Iterator<Text.Builder> {
+        public static final class Iterator implements java.util.Iterator<Text.Builder> {
             public Builder list;
             public int idx = 0;
             public Iterator(Builder list) {

--- a/runtime/src/main/java/org/capnproto/WirePointer.java
+++ b/runtime/src/main/java/org/capnproto/WirePointer.java
@@ -34,7 +34,7 @@ final class WirePointer {
     }
 
     public static int offsetAndKind(long wirePointer) {
-        return (int)(wirePointer & 0xffffffff);
+        return (int) wirePointer;
     }
 
     public static byte kind(long wirePointer) {


### PR DESCRIPTION
Perform small cleanups and optimizations that positively impact performance.

* Remove unnecessary bitwise and in WirePointer
* Remove always true condition in Serialize
* Pre-size segment ArrayList in Serialize
* Remove unused local var in Serialize
* Remove unnecessary bit shift in PackedOutputStream#write
* Make fields final in BuilderArena and Serialize
* Make Iterator classes static in DataList and TextList
* Pre-size ArrayList in ReaderArena constructor