### PR TITLE
Support MSVC compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Pending
+- Support MSVC compiler
+
 ## v0.1.15
 - Fix bugs in handling of upgraded list of pointers.
 

--- a/compiler/src/main/cpp/capnpc-java.c++
+++ b/compiler/src/main/cpp/capnpc-java.c++
@@ -34,9 +34,9 @@
 #ifdef _MSC_VER
 #include <io.h>
 #include <direct.h>
-#define STDIN_FILENO  0
-#define STDOUT_FILENO 1
-#define STDERR_FILENO 2
+#define STDIN_FILENO  _fileno( stdin )
+#define STDOUT_FILENO _fileno( stdout )
+#define STDERR_FILENO _fileno( stderr )
 #else
 #include <unistd.h>
 #endif


### PR DESCRIPTION
Tested in PowerShell with:

```
$env:PATH += ";$PWD\dependencies\capnproto-java\install\bin"

dependencies\capnproto\install\bin\capnp.exe compile -ojava `
  -Idependencies/capnproto-java/install/include `
  _deps/capnpc-java-src/examples/src/main/schema/addressbook.capnp
```
