### PR TITLE
Update WireHelpers.java to improve data-blob copying by bulk put

### DIFF
--- a/runtime/src/main/java/org/capnproto/WireHelpers.java
+++ b/runtime/src/main/java/org/capnproto/WireHelpers.java
@@ -850,11 +850,7 @@ final class WireHelpers {
                                        SegmentBuilder segment,
                                        Data.Reader value) {
         Data.Builder builder = initDataPointer(refOffset, segment, value.size);
-
-        // TODO is there a way to do this with bulk methods?
-        for (int i = 0; i < builder.size; ++i) {
-            builder.buffer.put(builder.offset + i, value.buffer.get(value.offset + i));
-        }
+        builder.buffer.put(value.buffer);
         return builder;
     }
 

--- a/runtime/src/main/java/org/capnproto/WireHelpers.java
+++ b/runtime/src/main/java/org/capnproto/WireHelpers.java
@@ -850,7 +850,14 @@ final class WireHelpers {
                                        SegmentBuilder segment,
                                        Data.Reader value) {
         Data.Builder builder = initDataPointer(refOffset, segment, value.size);
+        int originalSrcPosition = value.buffer.position();
+        int originalDstPosition = builder.buffer.position();
+        builder.buffer.position(builder.offset);
+        //# copy from src offset until src end
         builder.buffer.put(value.buffer);
+        //# restore original positions
+        builder.buffer.position(originalDstPosition);
+        value.buffer.position(originalSrcPosition);
         return builder;
     }
 


### PR DESCRIPTION
Hello maintainers!
For context: I am using capnproto-java for image processing pipelines in kotlin on android. For this matter, there is a lot of  ByteArrays for data buffers of image blobs.

Now while profiling I saw that the data copying has some nasty CPU-usage:
![image](https://github.com/user-attachments/assets/87717c18-6224-4115-a901-5489ab01bd52)
Almost a third of the copy operation is checkIndex().

And in the source code I saw [ this TODO](https://github.com/capnproto/capnproto-java/blob/e63801c153138e645b9f577d279614d757c321a0/runtime/src/main/java/org/capnproto/WireHelpers.java#L854).

I have seen that bulk ByteBuffer.put(byte[], int, int) and  ByteBuffer.put(ByteBuffer serc) is available [since Java 8](https://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffer.html). Is there a reason not to for minimal Java version?

I see the same issue in the code with getWritableDataPointer without taking a closer look.


Cheers
Steve

