### PR TITLE
chore: Upgrade test framework to JUnit5

### DIFF
--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -36,9 +36,9 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
             <scope>test</scope>
         </dependency>
 

--- a/compiler/src/test/java/org/capnproto/test/EncodingTest.java
+++ b/compiler/src/test/java/org/capnproto/test/EncodingTest.java
@@ -2,57 +2,57 @@ package org.capnproto.test;
 
 import org.capnproto.*;
 import org.capnproto.Void;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 public class EncodingTest {
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testAllTypes() {
         MessageBuilder message = new MessageBuilder();
-        Test.TestAllTypes.Builder allTypes = message.initRoot(Test.TestAllTypes.factory);
+        org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
         TestUtil.initTestMessage(allTypes);
         TestUtil.checkTestMessage(allTypes);
         TestUtil.checkTestMessage(allTypes.asReader());
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testAllTypesMultiSegment() {
         MessageBuilder message = new MessageBuilder(5, BuilderArena.AllocationStrategy.FIXED_SIZE);
-        Test.TestAllTypes.Builder allTypes = message.initRoot(Test.TestAllTypes.factory);
+        org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
         TestUtil.initTestMessage(allTypes);
 
         TestUtil.checkTestMessage(allTypes);
         TestUtil.checkTestMessage(allTypes.asReader());
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testSetters() {
         MessageBuilder message = new MessageBuilder();
-        Test.TestAllTypes.Builder allTypes = message.initRoot(Test.TestAllTypes.factory);
+        org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
         TestUtil.initTestMessage(allTypes);
 
         MessageBuilder message2 = new MessageBuilder();
-        Test.TestAllTypes.Builder allTypes2 = message2.initRoot(Test.TestAllTypes.factory);
+        org.capnproto.test.Test.TestAllTypes.Builder allTypes2 = message2.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
 
         allTypes2.setStructField(allTypes.asReader());
         TestUtil.checkTestMessage(allTypes2.getStructField());
 
-        Test.TestAllTypes.Reader reader = allTypes2.asReader().getStructField();
+        org.capnproto.test.Test.TestAllTypes.Reader reader = allTypes2.asReader().getStructField();
         TestUtil.checkTestMessage(reader);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testZeroing() {
         MessageBuilder message = new MessageBuilder();
-        Test.TestAllTypes.Builder allTypes = message.initRoot(Test.TestAllTypes.factory);
+        org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
 
-        StructList.Builder<Test.TestAllTypes.Builder> structList = allTypes.initStructList(3);
+        StructList.Builder<org.capnproto.test.Test.TestAllTypes.Builder> structList = allTypes.initStructList(3);
         TestUtil.initTestMessage(structList.get(0));
 
-        Test.TestAllTypes.Builder structField = allTypes.initStructField();
+        org.capnproto.test.Test.TestAllTypes.Builder structField = allTypes.initStructField();
         TestUtil.initTestMessage(structField);
 
         TestUtil.initTestMessage(structList.get(1));
@@ -61,19 +61,19 @@ public class EncodingTest {
         allTypes.initStructList(0);
 
         TestUtil.checkTestMessage(allTypes.getStructField());
-        Test.TestAllTypes.Reader allTypesReader = allTypes.asReader();
+        org.capnproto.test.Test.TestAllTypes.Reader allTypesReader = allTypes.asReader();
         TestUtil.checkTestMessage(allTypesReader.getStructField());
 
         AnyPointer.Builder any = message.initRoot(AnyPointer.factory);
         ByteBuffer[] segments = message.getSegmentsForOutput();
         for (ByteBuffer segment : segments) {
             for (int j = 0; j < segment.limit(); j++) {
-                Assert.assertEquals(segment.get(j), 0);
+                Assertions.assertEquals(segment.get(j), 0);
             }
         }
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testDoubleFarPointers() throws IOException {
         byte[] bytes = new byte[]{2, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0,
                 6, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0,
@@ -81,51 +81,51 @@ public class EncodingTest {
 
         ArrayInputStream input = new ArrayInputStream(java.nio.ByteBuffer.wrap(bytes));
         MessageReader message = org.capnproto.Serialize.read(input);
-        Test.TestAllTypes.Reader root = message.getRoot(Test.TestAllTypes.factory);
+        org.capnproto.test.Test.TestAllTypes.Reader root = message.getRoot(org.capnproto.test.Test.TestAllTypes.factory);
 
-        Assert.assertTrue(root.getBoolField());
-        Assert.assertEquals(root.getInt8Field(), 7);
-        Assert.assertEquals(root.getInt16Field(), 32767);
+        Assertions.assertTrue(root.getBoolField());
+        Assertions.assertEquals(root.getInt8Field(), 7);
+        Assertions.assertEquals(root.getInt16Field(), 32767);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testUpgradeStruct() {
       MessageBuilder builder = new MessageBuilder();
-      Test.TestAnyPointer.Builder root = builder.initRoot(Test.TestAnyPointer.factory);
+      org.capnproto.test.Test.TestAnyPointer.Builder root = builder.initRoot(org.capnproto.test.Test.TestAnyPointer.factory);
 
       {
-        Test.TestOldVersion.Builder oldVersion = root.getAnyPointerField().initAs(Test.TestOldVersion.factory);
+        org.capnproto.test.Test.TestOldVersion.Builder oldVersion = root.getAnyPointerField().initAs(org.capnproto.test.Test.TestOldVersion.factory);
         oldVersion.setOld1(123);
         oldVersion.setOld2("foo");
-        Test.TestOldVersion.Builder sub = oldVersion.initOld3();
+        org.capnproto.test.Test.TestOldVersion.Builder sub = oldVersion.initOld3();
         sub.setOld1(456);
         sub.setOld2("bar");
       }
 
       {
-        Test.TestNewVersion.Reader newVersion = root.getAnyPointerField().asReader().getAs(Test.TestNewVersion.factory);
-        Assert.assertEquals(newVersion.getOld1(), 123);
-        Assert.assertEquals(newVersion.getOld2().toString(), "foo");
-        Assert.assertEquals(newVersion.getNew2().toString(),  "baz");
-        Assert.assertEquals(newVersion.hasNew2(), false);
-        Assert.assertEquals(newVersion.hasNew3(), false);
+        org.capnproto.test.Test.TestNewVersion.Reader newVersion = root.getAnyPointerField().asReader().getAs(org.capnproto.test.Test.TestNewVersion.factory);
+        Assertions.assertEquals(newVersion.getOld1(), 123);
+        Assertions.assertEquals(newVersion.getOld2().toString(), "foo");
+        Assertions.assertEquals(newVersion.getNew2().toString(),  "baz");
+        Assertions.assertEquals(newVersion.hasNew2(), false);
+        Assertions.assertEquals(newVersion.hasNew3(), false);
       }
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testUpgradeStructReadAsOld() {
       MessageBuilder builder = new MessageBuilder();
-      Test.TestAnyPointer.Builder root = builder.initRoot(Test.TestAnyPointer.factory);
+      org.capnproto.test.Test.TestAnyPointer.Builder root = builder.initRoot(org.capnproto.test.Test.TestAnyPointer.factory);
 
       {
-        Test.TestNewVersion.Builder newVersion = root.getAnyPointerField().initAs(Test.TestNewVersion.factory);
+        org.capnproto.test.Test.TestNewVersion.Builder newVersion = root.getAnyPointerField().initAs(org.capnproto.test.Test.TestNewVersion.factory);
         newVersion.setOld1(123);
         newVersion.setOld2("foo");
-        Test.TestNewVersion.Builder sub = newVersion.initOld3();
+        org.capnproto.test.Test.TestNewVersion.Builder sub = newVersion.initOld3();
         sub.setOld1(456);
         sub.setOld2("bar");
 
-        StructList.Builder<Test.TestNewVersion.UpgradedFromText.Builder> names =
+        StructList.Builder<org.capnproto.test.Test.TestNewVersion.UpgradedFromText.Builder> names =
           newVersion.initOld4(2);
 
         names.get(0).setTextField("alice");
@@ -133,39 +133,39 @@ public class EncodingTest {
       }
 
       {
-        Test.TestOldVersion.Reader oldVersion = root.getAnyPointerField().asReader().getAs(Test.TestOldVersion.factory);
-        Assert.assertEquals(oldVersion.getOld1(), 123);
-        Assert.assertEquals(oldVersion.getOld2().toString(), "foo");
+        org.capnproto.test.Test.TestOldVersion.Reader oldVersion = root.getAnyPointerField().asReader().getAs(org.capnproto.test.Test.TestOldVersion.factory);
+        Assertions.assertEquals(oldVersion.getOld1(), 123);
+        Assertions.assertEquals(oldVersion.getOld2().toString(), "foo");
 
         TextList.Reader names = oldVersion.getOld4();
-        Assert.assertEquals(names.size(), 2);
-        Assert.assertEquals("alice", names.get(0).toString());
-        Assert.assertEquals("bob", names.get(1).toString());
+        Assertions.assertEquals(names.size(), 2);
+        Assertions.assertEquals("alice", names.get(0).toString());
+        Assertions.assertEquals("bob", names.get(1).toString());
       }
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testUpgradeStructInBuilder() {
         MessageBuilder builder = new MessageBuilder();
-        Test.TestAnyPointer.Builder root = builder.initRoot(Test.TestAnyPointer.factory);
+        org.capnproto.test.Test.TestAnyPointer.Builder root = builder.initRoot(org.capnproto.test.Test.TestAnyPointer.factory);
 
         {
-            Test.TestOldVersion.Builder oldVersion = root.getAnyPointerField().initAs(Test.TestOldVersion.factory);
+            org.capnproto.test.Test.TestOldVersion.Builder oldVersion = root.getAnyPointerField().initAs(org.capnproto.test.Test.TestOldVersion.factory);
             oldVersion.setOld1(123);
             oldVersion.setOld2("foo");
-            Test.TestOldVersion.Builder sub = oldVersion.initOld3();
+            org.capnproto.test.Test.TestOldVersion.Builder sub = oldVersion.initOld3();
             sub.setOld1(456);
             sub.setOld2("bar");
         }
         {
-            Test.TestNewVersion.Builder newVersion = root.getAnyPointerField().getAs(Test.TestNewVersion.factory);
-            Assert.assertEquals(newVersion.getOld1(), 123);
-            Assert.assertEquals(newVersion.getOld2().toString(), "foo");
-            Assert.assertEquals(newVersion.getNew1(), 987);
-            Assert.assertEquals(newVersion.getNew2().toString(), "baz");
-            Test.TestNewVersion.Builder sub = newVersion.getOld3();
-            Assert.assertEquals(sub.getOld1(), 456);
-            Assert.assertEquals(sub.getOld2().toString(), "bar");
+            org.capnproto.test.Test.TestNewVersion.Builder newVersion = root.getAnyPointerField().getAs(org.capnproto.test.Test.TestNewVersion.factory);
+            Assertions.assertEquals(newVersion.getOld1(), 123);
+            Assertions.assertEquals(newVersion.getOld2().toString(), "foo");
+            Assertions.assertEquals(newVersion.getNew1(), 987);
+            Assertions.assertEquals(newVersion.getNew2().toString(), "baz");
+            org.capnproto.test.Test.TestNewVersion.Builder sub = newVersion.getOld3();
+            Assertions.assertEquals(sub.getOld1(), 456);
+            Assertions.assertEquals(sub.getOld2().toString(), "bar");
 
             newVersion.setOld1(234);
             newVersion.setOld2("qux");
@@ -173,16 +173,16 @@ public class EncodingTest {
             newVersion.setNew2("quux");
         }
         {
-            Test.TestOldVersion.Builder oldVersion = root.getAnyPointerField().getAs(Test.TestOldVersion.factory);
-            Assert.assertEquals(oldVersion.getOld1(), 234);
-            Assert.assertEquals(oldVersion.getOld2().toString(), "qux");
+            org.capnproto.test.Test.TestOldVersion.Builder oldVersion = root.getAnyPointerField().getAs(org.capnproto.test.Test.TestOldVersion.factory);
+            Assertions.assertEquals(oldVersion.getOld1(), 234);
+            Assertions.assertEquals(oldVersion.getOld2().toString(), "qux");
         }
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testStructListUpgrade() {
         MessageBuilder message = new MessageBuilder();
-        Test.TestAnyPointer.Builder root = message.initRoot(Test.TestAnyPointer.factory);
+        org.capnproto.test.Test.TestAnyPointer.Builder root = message.initRoot(org.capnproto.test.Test.TestAnyPointer.factory);
         AnyPointer.Builder any = root.getAnyPointerField();
 
         {
@@ -192,37 +192,37 @@ public class EncodingTest {
             longs.set(2, 789);
         }
         {
-            StructList.Reader<Test.TestOldVersion.Reader> olds = any.asReader().getAs(Test.TestOldVersion.listFactory);
-            Assert.assertEquals(olds.get(0).getOld1(), 123);
-            Assert.assertEquals(olds.get(1).getOld1(), 456);
-            Assert.assertEquals(olds.get(2).getOld1(), 789);
+            StructList.Reader<org.capnproto.test.Test.TestOldVersion.Reader> olds = any.asReader().getAs(org.capnproto.test.Test.TestOldVersion.listFactory);
+            Assertions.assertEquals(olds.get(0).getOld1(), 123);
+            Assertions.assertEquals(olds.get(1).getOld1(), 456);
+            Assertions.assertEquals(olds.get(2).getOld1(), 789);
         }
         {
-            StructList.Builder<Test.TestOldVersion.Builder> olds = any.getAs(Test.TestOldVersion.listFactory);
-            Assert.assertEquals(olds.size(), 3);
-            Assert.assertEquals(olds.get(0).getOld1(), 123);
-            Assert.assertEquals(olds.get(1).getOld1(), 456);
-            Assert.assertEquals(olds.get(2).getOld1(), 789);
+            StructList.Builder<org.capnproto.test.Test.TestOldVersion.Builder> olds = any.getAs(org.capnproto.test.Test.TestOldVersion.listFactory);
+            Assertions.assertEquals(olds.size(), 3);
+            Assertions.assertEquals(olds.get(0).getOld1(), 123);
+            Assertions.assertEquals(olds.get(1).getOld1(), 456);
+            Assertions.assertEquals(olds.get(2).getOld1(), 789);
 
             olds.get(0).setOld2("zero");
             olds.get(1).setOld2("one");
             olds.get(2).setOld2("two");
         }
         {
-            StructList.Builder<Test.TestNewVersion.Builder> news = any.getAs(Test.TestNewVersion.listFactory);
-            Assert.assertEquals(news.size(), 3);
-            Assert.assertEquals(news.get(0).getOld1(), 123);
-            Assert.assertEquals(news.get(0).getOld2().toString(), "zero");
+            StructList.Builder<org.capnproto.test.Test.TestNewVersion.Builder> news = any.getAs(org.capnproto.test.Test.TestNewVersion.listFactory);
+            Assertions.assertEquals(news.size(), 3);
+            Assertions.assertEquals(news.get(0).getOld1(), 123);
+            Assertions.assertEquals(news.get(0).getOld2().toString(), "zero");
 
-            Assert.assertEquals(news.get(1).getOld1(), 456);
-            Assert.assertEquals(news.get(1).getOld2().toString(), "one");
+            Assertions.assertEquals(news.get(1).getOld1(), 456);
+            Assertions.assertEquals(news.get(1).getOld2().toString(), "one");
 
-            Assert.assertEquals(news.get(2).getOld1(), 789);
-            Assert.assertEquals(news.get(2).getOld2().toString(), "two");
+            Assertions.assertEquals(news.get(2).getOld1(), 789);
+            Assertions.assertEquals(news.get(2).getOld2().toString(), "two");
         }
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testStructListUpgradeDoubleFar() {
       byte[] bytes = new byte[]{
             1,0,0,0,0x1f,0,0,0, // list, inline composite, 3 words
@@ -236,236 +236,236 @@ public class EncodingTest {
       segment.order(java.nio.ByteOrder.LITTLE_ENDIAN);
       MessageReader messageReader = new MessageReader(new ByteBuffer[]{segment}, ReaderOptions.DEFAULT_READER_OPTIONS);
 
-      StructList.Reader<Test.TestOldVersion.Reader> oldVersion = messageReader.getRoot(StructList.newFactory(Test.TestOldVersion.factory));
+      StructList.Reader<org.capnproto.test.Test.TestOldVersion.Reader> oldVersion = messageReader.getRoot(StructList.newFactory(org.capnproto.test.Test.TestOldVersion.factory));
 
-      Assert.assertEquals(oldVersion.size(), 1);
-      Assert.assertEquals(oldVersion.get(0).getOld1(), 91);
-      Assert.assertEquals(oldVersion.get(0).getOld2().toString(), "hello!!");
+      Assertions.assertEquals(oldVersion.size(), 1);
+      Assertions.assertEquals(oldVersion.get(0).getOld1(), 91);
+      Assertions.assertEquals(oldVersion.get(0).getOld2().toString(), "hello!!");
 
       // Make the first segment exactly large enough to fit the original message.
       // This leaves no room for a far pointer landing pad in the first segment.
       MessageBuilder message = new MessageBuilder(6);
-      message.setRoot(StructList.newFactory(Test.TestOldVersion.factory), oldVersion);
+      message.setRoot(StructList.newFactory(org.capnproto.test.Test.TestOldVersion.factory), oldVersion);
 
       ByteBuffer[] segments = message.getSegmentsForOutput();
-      Assert.assertEquals(segments.length, 1);
-      Assert.assertEquals(segments[0].limit(), 6 * 8);
+      Assertions.assertEquals(segments.length, 1);
+      Assertions.assertEquals(segments[0].limit(), 6 * 8);
 
-      StructList.Builder<Test.TestNewVersion.Builder> newVersion =
-        message.getRoot(new StructList.Factory<Test.TestNewVersion.Builder, Test.TestNewVersion.Reader>(Test.TestNewVersion.factory));
-      Assert.assertEquals(newVersion.size(), 1);
-      Assert.assertEquals(newVersion.get(0).getOld1(), 91);
-      Assert.assertEquals(newVersion.get(0).getOld2().toString(), "hello!!");
+      StructList.Builder<org.capnproto.test.Test.TestNewVersion.Builder> newVersion =
+        message.getRoot(new StructList.Factory<org.capnproto.test.Test.TestNewVersion.Builder, org.capnproto.test.Test.TestNewVersion.Reader>(org.capnproto.test.Test.TestNewVersion.factory));
+      Assertions.assertEquals(newVersion.size(), 1);
+      Assertions.assertEquals(newVersion.get(0).getOld1(), 91);
+      Assertions.assertEquals(newVersion.get(0).getOld2().toString(), "hello!!");
 
       ByteBuffer[] segments1 = message.getSegmentsForOutput();
-      Assert.assertEquals(segments[0].limit(), 6 * 8);
+      Assertions.assertEquals(segments[0].limit(), 6 * 8);
       for (int ii = 8; ii < (5 * 8) - 1; ++ii) {
         // Check the the old list, including the tag, was zeroed.
-        Assert.assertEquals(segments[0].get(ii), 0);
+        Assertions.assertEquals(segments[0].get(ii), 0);
       }
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testListBuilderAsReader() {
       MessageBuilder message = new MessageBuilder();
-      Test.TestAllTypes.Builder allTypes = message.initRoot(Test.TestAllTypes.factory);
+      org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
 
       allTypes.initVoidList(10);
-      Assert.assertEquals(allTypes.getVoidList().asReader().size(), 10);
+      Assertions.assertEquals(allTypes.getVoidList().asReader().size(), 10);
 
       PrimitiveList.Boolean.Builder boolList = allTypes.initBoolList(7);
       boolList.set(3, true);
       PrimitiveList.Boolean.Reader boolListReader = boolList.asReader();
-      Assert.assertEquals(boolListReader.size(), 7);
-      Assert.assertEquals(boolListReader.get(0), false);
-      Assert.assertEquals(boolListReader.get(1), false);
-      Assert.assertEquals(boolListReader.get(2), false);
-      Assert.assertEquals(boolListReader.get(3), true);
-      Assert.assertEquals(boolListReader.get(4), false);
+      Assertions.assertEquals(boolListReader.size(), 7);
+      Assertions.assertEquals(boolListReader.get(0), false);
+      Assertions.assertEquals(boolListReader.get(1), false);
+      Assertions.assertEquals(boolListReader.get(2), false);
+      Assertions.assertEquals(boolListReader.get(3), true);
+      Assertions.assertEquals(boolListReader.get(4), false);
 
       PrimitiveList.Byte.Builder int8List = allTypes.initInt8List(9);
       int8List.set(4, (byte)100);
       int8List.set(8, (byte)11);
       PrimitiveList.Byte.Reader int8ListReader = int8List.asReader();
-      Assert.assertEquals(int8ListReader.size(), 9);
-      Assert.assertEquals(int8ListReader.get(0), 0);
-      Assert.assertEquals(int8ListReader.get(4), 100);
-      Assert.assertEquals(int8ListReader.get(8), 11);
+      Assertions.assertEquals(int8ListReader.size(), 9);
+      Assertions.assertEquals(int8ListReader.get(0), 0);
+      Assertions.assertEquals(int8ListReader.get(4), 100);
+      Assertions.assertEquals(int8ListReader.get(8), 11);
 
       PrimitiveList.Short.Builder int16List = allTypes.initInt16List(2);
       int16List.set(0, (short)1);
       PrimitiveList.Short.Reader int16ListReader = int16List.asReader();
-      Assert.assertEquals(int16ListReader.size(), 2);
-      Assert.assertEquals(int16ListReader.get(0), 1);
-      Assert.assertEquals(int16ListReader.get(1), 0);
+      Assertions.assertEquals(int16ListReader.size(), 2);
+      Assertions.assertEquals(int16ListReader.get(0), 1);
+      Assertions.assertEquals(int16ListReader.get(1), 0);
 
       // TODO other primitive lists
 
       TextList.Builder textList = allTypes.initTextList(1);
       textList.set(0, new Text.Reader("abcdefg"));
       TextList.Reader textListReader = textList.asReader();
-      Assert.assertEquals(textListReader.size(), 1);
-      Assert.assertEquals(textListReader.get(0).toString(), "abcdefg");
+      Assertions.assertEquals(textListReader.size(), 1);
+      Assertions.assertEquals(textListReader.get(0).toString(), "abcdefg");
 
       DataList.Builder dataList = allTypes.initDataList(1);
       dataList.set(0, new Data.Reader(new byte[]{1,2,3,4}));
       DataList.Reader dataListReader = dataList.asReader();
-      Assert.assertEquals(dataListReader.size(), 1);
-      Assert.assertTrue(java.util.Arrays.equals(dataListReader.get(0).toArray(), new byte[]{1,2,3,4}));
+      Assertions.assertEquals(dataListReader.size(), 1);
+      Assertions.assertTrue(java.util.Arrays.equals(dataListReader.get(0).toArray(), new byte[]{1,2,3,4}));
 
-      StructList.Builder<Test.TestAllTypes.Builder> structList = allTypes.initStructList(2);
+      StructList.Builder<org.capnproto.test.Test.TestAllTypes.Builder> structList = allTypes.initStructList(2);
       structList.get(0).setInt8Field((byte)5);
       structList.get(1).setInt8Field((byte)9);
-      StructList.Reader<Test.TestAllTypes.Reader> structListReader = structList.asReader(Test.TestAllTypes.factory);
-      Assert.assertEquals(structListReader.size(), 2);
-      Assert.assertEquals(structListReader.get(0).getInt8Field(), 5);
-      Assert.assertEquals(structListReader.get(1).getInt8Field(), 9);
+      StructList.Reader<org.capnproto.test.Test.TestAllTypes.Reader> structListReader = structList.asReader(org.capnproto.test.Test.TestAllTypes.factory);
+      Assertions.assertEquals(structListReader.size(), 2);
+      Assertions.assertEquals(structListReader.get(0).getInt8Field(), 5);
+      Assertions.assertEquals(structListReader.get(1).getInt8Field(), 9);
 
-      EnumList.Builder<Test.TestEnum> enumList = allTypes.initEnumList(3);
-      enumList.set(0, Test.TestEnum.FOO);
-      enumList.set(1, Test.TestEnum.BAR);
-      enumList.set(2, Test.TestEnum.BAZ);
-      EnumList.Reader<Test.TestEnum> enumListReader = enumList.asReader();
-      Assert.assertEquals(enumListReader.size(), 3);
-      Assert.assertEquals(enumListReader.get(0), Test.TestEnum.FOO);
-      Assert.assertEquals(enumListReader.get(1), Test.TestEnum.BAR);
-      Assert.assertEquals(enumListReader.get(2), Test.TestEnum.BAZ);
+      EnumList.Builder<org.capnproto.test.Test.TestEnum> enumList = allTypes.initEnumList(3);
+      enumList.set(0, org.capnproto.test.Test.TestEnum.FOO);
+      enumList.set(1, org.capnproto.test.Test.TestEnum.BAR);
+      enumList.set(2, org.capnproto.test.Test.TestEnum.BAZ);
+      EnumList.Reader<org.capnproto.test.Test.TestEnum> enumListReader = enumList.asReader();
+      Assertions.assertEquals(enumListReader.size(), 3);
+      Assertions.assertEquals(enumListReader.get(0), org.capnproto.test.Test.TestEnum.FOO);
+      Assertions.assertEquals(enumListReader.get(1), org.capnproto.test.Test.TestEnum.BAR);
+      Assertions.assertEquals(enumListReader.get(2), org.capnproto.test.Test.TestEnum.BAZ);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testNestedListBuilderAsReader() {
       MessageBuilder builder = new MessageBuilder();
-      Test.TestLists.Builder root = builder.initRoot(Test.TestLists.factory);
+      org.capnproto.test.Test.TestLists.Builder root = builder.initRoot(org.capnproto.test.Test.TestLists.factory);
 
-      ListList.Builder<StructList.Builder<Test.TestAllTypes.Builder>> structListList = root.initStructListList(3);
-      StructList.Builder<Test.TestAllTypes.Builder> structList0 = structListList.init(0, 1);
+      ListList.Builder<StructList.Builder<org.capnproto.test.Test.TestAllTypes.Builder>> structListList = root.initStructListList(3);
+      StructList.Builder<org.capnproto.test.Test.TestAllTypes.Builder> structList0 = structListList.init(0, 1);
       structList0.get(0).setInt16Field((short)1);
       // leave structList1 as default
-      StructList.Builder<Test.TestAllTypes.Builder> structList2 = structListList.init(2, 3);
+      StructList.Builder<org.capnproto.test.Test.TestAllTypes.Builder> structList2 = structListList.init(2, 3);
       structList2.get(0).setInt16Field((short)22);
       structList2.get(1).setInt16Field((short)333);
       structList2.get(2).setInt16Field((short)4444);
 
-      ListList.Reader<StructList.Reader<Test.TestAllTypes.Reader>> structListListReader =
-        structListList.asReader(StructList.newFactory(Test.TestAllTypes.factory));
-      Assert.assertEquals(structListListReader.size(), 3);
-      StructList.Reader<Test.TestAllTypes.Reader> structList0Reader = structListListReader.get(0);
-      Assert.assertEquals(structList0Reader.size(), 1);
-      Assert.assertEquals(structList0Reader.get(0).getInt16Field(), 1);
-      Assert.assertEquals(structListListReader.get(1).size(), 0);
-      StructList.Reader<Test.TestAllTypes.Reader> structList2Reader = structListListReader.get(2);
-      Assert.assertEquals(structList2Reader.size(), 3);
-      Assert.assertEquals(structList2Reader.get(0).getInt16Field(), 22);
-      Assert.assertEquals(structList2Reader.get(1).getInt16Field(), 333);
-      Assert.assertEquals(structList2Reader.get(2).getInt16Field(), 4444);
+      ListList.Reader<StructList.Reader<org.capnproto.test.Test.TestAllTypes.Reader>> structListListReader =
+        structListList.asReader(StructList.newFactory(org.capnproto.test.Test.TestAllTypes.factory));
+      Assertions.assertEquals(structListListReader.size(), 3);
+      StructList.Reader<org.capnproto.test.Test.TestAllTypes.Reader> structList0Reader = structListListReader.get(0);
+      Assertions.assertEquals(structList0Reader.size(), 1);
+      Assertions.assertEquals(structList0Reader.get(0).getInt16Field(), 1);
+      Assertions.assertEquals(structListListReader.get(1).size(), 0);
+      StructList.Reader<org.capnproto.test.Test.TestAllTypes.Reader> structList2Reader = structListListReader.get(2);
+      Assertions.assertEquals(structList2Reader.size(), 3);
+      Assertions.assertEquals(structList2Reader.get(0).getInt16Field(), 22);
+      Assertions.assertEquals(structList2Reader.get(1).getInt16Field(), 333);
+      Assertions.assertEquals(structList2Reader.get(2).getInt16Field(), 4444);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testGenerics() {
         MessageBuilder message = new MessageBuilder();
 
-        Test.TestGenerics.Builder<Test.TestAllTypes.Builder, Text.Builder> root =
-            (Test.TestGenerics.Builder<Test.TestAllTypes.Builder, Text.Builder>) message.initRoot(Test.TestGenerics.newFactory(Test.TestAllTypes.factory, Text.factory));
+        org.capnproto.test.Test.TestGenerics.Builder<org.capnproto.test.Test.TestAllTypes.Builder, Text.Builder> root =
+            (org.capnproto.test.Test.TestGenerics.Builder<org.capnproto.test.Test.TestAllTypes.Builder, Text.Builder>) message.initRoot(org.capnproto.test.Test.TestGenerics.newFactory(org.capnproto.test.Test.TestAllTypes.factory, Text.factory));
         TestUtil.initTestMessage(root.getFoo());
         root.getDub().setFoo(Text.factory, new Text.Reader("Hello"));
 
         PrimitiveList.Byte.Builder bar = root.getDub().initBar(1);
         bar.set(0, (byte) 11);
-        Test.TestAllTypes.Builder revBar = root.getRev().getBar();
+        org.capnproto.test.Test.TestAllTypes.Builder revBar = root.getRev().getBar();
         revBar.setInt8Field((byte) 111);
         PrimitiveList.Boolean.Builder boolList = revBar.initBoolList(2);
         boolList.set(0, false);
         boolList.set(1, true);
 
         TestUtil.checkTestMessage(root.getFoo());
-        Test.TestGenerics.Reader<Test.TestAllTypes.Reader, Text.Reader> rootReader =
-            root.asReader(Test.TestGenerics.newFactory(Test.TestAllTypes.factory, Text.factory));
+        org.capnproto.test.Test.TestGenerics.Reader<org.capnproto.test.Test.TestAllTypes.Reader, Text.Reader> rootReader =
+            root.asReader(org.capnproto.test.Test.TestGenerics.newFactory(org.capnproto.test.Test.TestAllTypes.factory, Text.factory));
         TestUtil.checkTestMessage(rootReader.getFoo());
-        Test.TestGenerics.Builder<Text.Builder, PrimitiveList.Byte.Builder> dubReader = root.getDub();
-        Assert.assertEquals(dubReader.getFoo().toString(), "Hello");
+        org.capnproto.test.Test.TestGenerics.Builder<Text.Builder, PrimitiveList.Byte.Builder> dubReader = root.getDub();
+        Assertions.assertEquals(dubReader.getFoo().toString(), "Hello");
         PrimitiveList.Byte.Builder barReader = dubReader.getBar();
-        Assert.assertEquals(1, barReader.size());
-        Assert.assertEquals(11, barReader.get(0));
+        Assertions.assertEquals(1, barReader.size());
+        Assertions.assertEquals(11, barReader.get(0));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testUseGenerics() {
         MessageBuilder message = new MessageBuilder();
-        Test.TestUseGenerics.Builder root = message.initRoot(Test.TestUseGenerics.factory);
+        org.capnproto.test.Test.TestUseGenerics.Builder root = message.initRoot(org.capnproto.test.Test.TestUseGenerics.factory);
         {
             MessageBuilder message2 = new MessageBuilder();
-            Test.TestGenerics.Factory<AnyPointer.Builder, AnyPointer.Reader, AnyPointer.Builder, AnyPointer.Reader> factory2 = Test.TestGenerics.newFactory(AnyPointer.factory, AnyPointer.factory);
-            Test.TestGenerics.Builder<AnyPointer.Builder, AnyPointer.Builder> root2 = message2.initRoot(factory2);
+            org.capnproto.test.Test.TestGenerics.Factory<AnyPointer.Builder, AnyPointer.Reader, AnyPointer.Builder, AnyPointer.Reader> factory2 = org.capnproto.test.Test.TestGenerics.newFactory(AnyPointer.factory, AnyPointer.factory);
+            org.capnproto.test.Test.TestGenerics.Builder<AnyPointer.Builder, AnyPointer.Builder> root2 = message2.initRoot(factory2);
             root2.initDub().setFoo(Text.factory, new Text.Reader("foobar"));
 
             root.setUnspecified(factory2, root2.asReader(factory2));
         }
 
-        Assert.assertEquals("foobar", root.getUnspecified().getDub().getFoo().toString());
+        Assertions.assertEquals("foobar", root.getUnspecified().getDub().getFoo().toString());
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testDefaults() {
         MessageBuilder message = new MessageBuilder();
-        Test.TestDefaults.Builder defaults = message.initRoot(Test.TestDefaults.factory);
+        org.capnproto.test.Test.TestDefaults.Builder defaults = message.initRoot(org.capnproto.test.Test.TestDefaults.factory);
         TestUtil.checkDefaultMessage(defaults);
         TestUtil.checkDefaultMessage(defaults.asReader());
         TestUtil.setDefaultMessage(defaults);
         TestUtil.checkSettedDefaultMessage(defaults.asReader());
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testUnions() {
       MessageBuilder builder = new MessageBuilder();
-      Test.TestUnion.Builder root = builder.initRoot(Test.TestUnion.factory);
-      Test.TestUnion.Union0.Builder u0 = root.initUnion0();
+      org.capnproto.test.Test.TestUnion.Builder root = builder.initRoot(org.capnproto.test.Test.TestUnion.factory);
+      org.capnproto.test.Test.TestUnion.Union0.Builder u0 = root.initUnion0();
       u0.initU0f1sp(10);
-      Assert.assertEquals(u0.which(), Test.TestUnion.Union0.Which.U0F1SP);
+      Assertions.assertEquals(u0.which(), org.capnproto.test.Test.TestUnion.Union0.Which.U0F1SP);
 
       u0.initPrimitiveList(10);
-      Assert.assertEquals(u0.which(), Test.TestUnion.Union0.Which.PRIMITIVE_LIST);
+      Assertions.assertEquals(u0.which(), org.capnproto.test.Test.TestUnion.Union0.Which.PRIMITIVE_LIST);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testGroups() {
         MessageBuilder builder = new MessageBuilder();
-        Test.TestGroups.Builder root = builder.initRoot(Test.TestGroups.factory);
+        org.capnproto.test.Test.TestGroups.Builder root = builder.initRoot(org.capnproto.test.Test.TestGroups.factory);
         {
-            Test.TestGroups.Groups.Foo.Builder foo = root.getGroups().initFoo();
+            org.capnproto.test.Test.TestGroups.Groups.Foo.Builder foo = root.getGroups().initFoo();
             foo.setCorge(12345678);
             foo.setGrault(123456789012345L);
             foo.setGarply(new Text.Reader("foobar"));
 
-            Assert.assertEquals(12345678, foo.getCorge());
-            Assert.assertEquals(123456789012345L, foo.getGrault());
-            Assert.assertEquals("foobar", foo.getGarply().toString());
+            Assertions.assertEquals(12345678, foo.getCorge());
+            Assertions.assertEquals(123456789012345L, foo.getGrault());
+            Assertions.assertEquals("foobar", foo.getGarply().toString());
         }
         {
-            Test.TestGroups.Groups.Bar.Builder bar = root.getGroups().initBar();
+            org.capnproto.test.Test.TestGroups.Groups.Bar.Builder bar = root.getGroups().initBar();
             bar.setCorge(23456789);
             bar.setGrault(new Text.Reader("barbaz"));
             bar.setGarply(234567890123456L);
 
-            Assert.assertEquals(23456789, bar.getCorge());
-            Assert.assertEquals("barbaz", bar.getGrault().toString());
-            Assert.assertEquals(234567890123456L, bar.getGarply());
+            Assertions.assertEquals(23456789, bar.getCorge());
+            Assertions.assertEquals("barbaz", bar.getGrault().toString());
+            Assertions.assertEquals(234567890123456L, bar.getGarply());
         }
         {
-            Test.TestGroups.Groups.Baz.Builder baz = root.getGroups().initBaz();
+            org.capnproto.test.Test.TestGroups.Groups.Baz.Builder baz = root.getGroups().initBaz();
             baz.setCorge(34567890);
             baz.setGrault(new Text.Reader("bazqux"));
             baz.setGarply(new Text.Reader("quxquux"));
 
-            Assert.assertEquals(34567890, baz.getCorge());
-            Assert.assertEquals("bazqux", baz.getGrault().toString());
-            Assert.assertEquals("quxquux", baz.getGarply().toString());
+            Assertions.assertEquals(34567890, baz.getCorge());
+            Assertions.assertEquals("bazqux", baz.getGrault().toString());
+            Assertions.assertEquals("quxquux", baz.getGarply().toString());
         }
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testNestedLists() {
         MessageBuilder builder = new MessageBuilder();
-        Test.TestLists.Builder root = builder.initRoot(Test.TestLists.factory);
+        org.capnproto.test.Test.TestLists.Builder root = builder.initRoot(org.capnproto.test.Test.TestLists.factory);
         {
             ListList.Builder<PrimitiveList.Int.Builder> intListList = root.initInt32ListList(2);
             PrimitiveList.Int.Builder intList0 = intListList.init(0, 4);
@@ -477,120 +477,120 @@ public class EncodingTest {
             intList1.set(0, 100);
         }
         {
-            Test.TestLists.Reader reader = root.asReader();
+            org.capnproto.test.Test.TestLists.Reader reader = root.asReader();
             ListList.Reader<PrimitiveList.Int.Reader> intListList = reader.getInt32ListList();
-            Assert.assertEquals(2, intListList.size());
+            Assertions.assertEquals(2, intListList.size());
             PrimitiveList.Int.Reader intList0 = intListList.get(0);
-            Assert.assertEquals(4, intList0.size());
-            Assert.assertEquals(1, intList0.get(0));
-            Assert.assertEquals(2, intList0.get(1));
-            Assert.assertEquals(3, intList0.get(2));
-            Assert.assertEquals(4, intList0.get(3));
+            Assertions.assertEquals(4, intList0.size());
+            Assertions.assertEquals(1, intList0.get(0));
+            Assertions.assertEquals(2, intList0.get(1));
+            Assertions.assertEquals(3, intList0.get(2));
+            Assertions.assertEquals(4, intList0.get(3));
             PrimitiveList.Int.Reader intList1 = intListList.get(1);
-            Assert.assertEquals(1, intList1.size());
-            Assert.assertEquals(100, intList1.get(0));
+            Assertions.assertEquals(1, intList1.size());
+            Assertions.assertEquals(100, intList1.get(0));
         }
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testConstants() {
-        Assert.assertEquals(Void.VOID, Test.TestConstants.VOID_CONST);
-        Assert.assertEquals(true, Test.TestConstants.BOOL_CONST);
-        Assert.assertEquals(-123, Test.TestConstants.INT8_CONST);
-        Assert.assertEquals(-12345, Test.TestConstants.INT16_CONST);
-        Assert.assertEquals(-12345678, Test.TestConstants.INT32_CONST);
-        Assert.assertEquals(-123456789012345L, Test.TestConstants.INT64_CONST);
+        Assertions.assertEquals(Void.VOID, org.capnproto.test.Test.TestConstants.VOID_CONST);
+        Assertions.assertEquals(true, org.capnproto.test.Test.TestConstants.BOOL_CONST);
+        Assertions.assertEquals(-123, org.capnproto.test.Test.TestConstants.INT8_CONST);
+        Assertions.assertEquals(-12345, org.capnproto.test.Test.TestConstants.INT16_CONST);
+        Assertions.assertEquals(-12345678, org.capnproto.test.Test.TestConstants.INT32_CONST);
+        Assertions.assertEquals(-123456789012345L, org.capnproto.test.Test.TestConstants.INT64_CONST);
 
-        Assert.assertEquals(-22, Test.TestConstants.UINT8_CONST);
-        Assert.assertEquals(-19858, Test.TestConstants.UINT16_CONST);
-        Assert.assertEquals(-838178284, Test.TestConstants.UINT32_CONST);
-        Assert.assertEquals(-6101065172474983726L, Test.TestConstants.UINT64_CONST);
+        Assertions.assertEquals(-22, org.capnproto.test.Test.TestConstants.UINT8_CONST);
+        Assertions.assertEquals(-19858, org.capnproto.test.Test.TestConstants.UINT16_CONST);
+        Assertions.assertEquals(-838178284, org.capnproto.test.Test.TestConstants.UINT32_CONST);
+        Assertions.assertEquals(-6101065172474983726L, org.capnproto.test.Test.TestConstants.UINT64_CONST);
 
-        Assert.assertEquals(1234.5f, Test.TestConstants.FLOAT32_CONST, TestUtil.DELTA);
-        Assert.assertEquals(-123e45, Test.TestConstants.FLOAT64_CONST, TestUtil.DELTA);
+        Assertions.assertEquals(1234.5f, org.capnproto.test.Test.TestConstants.FLOAT32_CONST, TestUtil.DELTA);
+        Assertions.assertEquals(-123e45, org.capnproto.test.Test.TestConstants.FLOAT64_CONST, TestUtil.DELTA);
 
-        Assert.assertEquals("foo", Test.TestConstants.TEXT_CONST.toString());
-        Assert.assertArrayEquals(TestUtil.data("bar"), Test.TestConstants.DATA_CONST.toArray());
+        Assertions.assertEquals("foo", org.capnproto.test.Test.TestConstants.TEXT_CONST.toString());
+        Assertions.assertArrayEquals(TestUtil.data("bar"), org.capnproto.test.Test.TestConstants.DATA_CONST.toArray());
 
-        Assert.assertEquals(Test.TestEnum.CORGE, Test.TestConstants.ENUM_CONST);
+        Assertions.assertEquals(org.capnproto.test.Test.TestEnum.CORGE, org.capnproto.test.Test.TestConstants.ENUM_CONST);
         {
-            Test.TestAllTypes.Reader subReader = Test.TestConstants.STRUCT_CONST;
-            Assert.assertEquals(subReader.getBoolField(), true);
-            Assert.assertEquals(subReader.getInt8Field(), -12);
-            Assert.assertEquals(subReader.getInt16Field(), 3456);
-            Assert.assertEquals(subReader.getInt32Field(), -78901234);
-            Assert.assertEquals(subReader.getInt64Field(), 56789012345678L);
-            Assert.assertEquals(subReader.getUInt8Field(), 90);
-            Assert.assertEquals(subReader.getUInt16Field(), 1234);
-            Assert.assertEquals(subReader.getUInt32Field(), 56789012);
-            Assert.assertEquals(subReader.getUInt64Field(), 345678901234567890L);
-            Assert.assertEquals(subReader.getFloat32Field(), -1.25e-10f, TestUtil.DELTA);
-            Assert.assertEquals(subReader.getFloat64Field(), 345, TestUtil.DELTA);
-            Assert.assertEquals(subReader.getTextField().toString(), "baz");
+            org.capnproto.test.Test.TestAllTypes.Reader subReader = org.capnproto.test.Test.TestConstants.STRUCT_CONST;
+            Assertions.assertEquals(subReader.getBoolField(), true);
+            Assertions.assertEquals(subReader.getInt8Field(), -12);
+            Assertions.assertEquals(subReader.getInt16Field(), 3456);
+            Assertions.assertEquals(subReader.getInt32Field(), -78901234);
+            Assertions.assertEquals(subReader.getInt64Field(), 56789012345678L);
+            Assertions.assertEquals(subReader.getUInt8Field(), 90);
+            Assertions.assertEquals(subReader.getUInt16Field(), 1234);
+            Assertions.assertEquals(subReader.getUInt32Field(), 56789012);
+            Assertions.assertEquals(subReader.getUInt64Field(), 345678901234567890L);
+            Assertions.assertEquals(subReader.getFloat32Field(), -1.25e-10f, TestUtil.DELTA);
+            Assertions.assertEquals(subReader.getFloat64Field(), 345, TestUtil.DELTA);
+            Assertions.assertEquals(subReader.getTextField().toString(), "baz");
         }
 
-        Assert.assertEquals(6, Test.TestConstants.VOID_LIST_CONST.size());
+        Assertions.assertEquals(6, org.capnproto.test.Test.TestConstants.VOID_LIST_CONST.size());
 
         {
-            PrimitiveList.Boolean.Reader listReader = Test.TestConstants.BOOL_LIST_CONST;
-            Assert.assertEquals(4, listReader.size());
-            Assert.assertEquals(true, listReader.get(0));
-            Assert.assertEquals(false, listReader.get(1));
-            Assert.assertEquals(false, listReader.get(2));
-            Assert.assertEquals(true, listReader.get(3));
-        }
-
-        {
-            TextList.Reader listReader = Test.TestConstants.TEXT_LIST_CONST;
-            Assert.assertEquals(3, listReader.size());
-            Assert.assertEquals("plugh", listReader.get(0).toString());
-            Assert.assertEquals("xyzzy", listReader.get(1).toString());
-            Assert.assertEquals("thud", listReader.get(2).toString());
+            PrimitiveList.Boolean.Reader listReader = org.capnproto.test.Test.TestConstants.BOOL_LIST_CONST;
+            Assertions.assertEquals(4, listReader.size());
+            Assertions.assertEquals(true, listReader.get(0));
+            Assertions.assertEquals(false, listReader.get(1));
+            Assertions.assertEquals(false, listReader.get(2));
+            Assertions.assertEquals(true, listReader.get(3));
         }
 
         {
-            StructList.Reader<Test.TestAllTypes.Reader> listReader = Test.TestConstants.STRUCT_LIST_CONST;
-            Assert.assertEquals(3, listReader.size());
-            Assert.assertEquals("structlist 1", listReader.get(0).getTextField().toString());
-            Assert.assertEquals("structlist 2", listReader.get(1).getTextField().toString());
-            Assert.assertEquals("structlist 3", listReader.get(2).getTextField().toString());
+            TextList.Reader listReader = org.capnproto.test.Test.TestConstants.TEXT_LIST_CONST;
+            Assertions.assertEquals(3, listReader.size());
+            Assertions.assertEquals("plugh", listReader.get(0).toString());
+            Assertions.assertEquals("xyzzy", listReader.get(1).toString());
+            Assertions.assertEquals("thud", listReader.get(2).toString());
+        }
+
+        {
+            StructList.Reader<org.capnproto.test.Test.TestAllTypes.Reader> listReader = org.capnproto.test.Test.TestConstants.STRUCT_LIST_CONST;
+            Assertions.assertEquals(3, listReader.size());
+            Assertions.assertEquals("structlist 1", listReader.get(0).getTextField().toString());
+            Assertions.assertEquals("structlist 2", listReader.get(1).getTextField().toString());
+            Assertions.assertEquals("structlist 3", listReader.get(2).getTextField().toString());
         }
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testGlobalConstants() {
-        Assert.assertEquals(Test.GLOBAL_INT, 12345);
+        Assertions.assertEquals(org.capnproto.test.Test.GLOBAL_INT, 12345);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testEmptyStruct() {
         MessageBuilder builder = new MessageBuilder();
-        Test.TestAnyPointer.Builder root = builder.initRoot(Test.TestAnyPointer.factory);
+        org.capnproto.test.Test.TestAnyPointer.Builder root = builder.initRoot(org.capnproto.test.Test.TestAnyPointer.factory);
 
-        Assert.assertFalse(root.hasAnyPointerField());
+        Assertions.assertFalse(root.hasAnyPointerField());
 
         AnyPointer.Builder any = root.getAnyPointerField();
-        Assert.assertTrue(any.isNull());
-        any.initAs(Test.TestEmptyStruct.factory);
-        Assert.assertFalse(any.isNull());
-        Assert.assertTrue(root.hasAnyPointerField());
+        Assertions.assertTrue(any.isNull());
+        any.initAs(org.capnproto.test.Test.TestEmptyStruct.factory);
+        Assertions.assertFalse(any.isNull());
+        Assertions.assertTrue(root.hasAnyPointerField());
 
         {
-            Test.TestAnyPointer.Reader reader = root.asReader();
-            Assert.assertTrue(reader.hasAnyPointerField());
-            Assert.assertNotNull(reader.getAnyPointerField());
+            org.capnproto.test.Test.TestAnyPointer.Reader reader = root.asReader();
+            Assertions.assertTrue(reader.hasAnyPointerField());
+            Assertions.assertNotNull(reader.getAnyPointerField());
         }
     }
 
-    @org.junit.Test(expected=DecodeException.class)
+    @org.junit.jupiter.api.Test
     public void testTextBuilderIntUnderflow() {
         MessageBuilder builder = new MessageBuilder();
-        Test.TestAnyPointer.Builder root = builder.initRoot(Test.TestAnyPointer.factory);
+        org.capnproto.test.Test.TestAnyPointer.Builder root = builder.initRoot(org.capnproto.test.Test.TestAnyPointer.factory);
         root.getAnyPointerField().initAs(Data.factory, 0);
-        root.getAnyPointerField().getAs(Text.factory);
+        Assertions.assertThrows(DecodeException.class, () -> root.getAnyPointerField().getAs(Text.factory));
     }
 
-    @org.junit.Test(expected=DecodeException.class)
+    @org.junit.jupiter.api.Test
     public void testInlineCompositeListIntOverflow() throws DecodeException {
 
         byte[] bytes = new byte[]{0,0,0,0, 0,0,1,0, 1,0,0,0, 0x17,0,0,0, 0,0,0,-128, 16,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0};
@@ -599,11 +599,11 @@ public class EncodingTest {
         segment.order(ByteOrder.LITTLE_ENDIAN);
         MessageReader message = new MessageReader(new ByteBuffer[]{segment}, ReaderOptions.DEFAULT_READER_OPTIONS);
 
-        Test.TestAnyPointer.Reader root = message.getRoot(Test.TestAnyPointer.factory);
-        root.getAnyPointerField().getAs(StructList.newFactory(Test.TestAllTypes.factory));
+        org.capnproto.test.Test.TestAnyPointer.Reader root = message.getRoot(org.capnproto.test.Test.TestAnyPointer.factory);
+        Assertions.assertThrows(DecodeException.class, () -> root.getAnyPointerField().getAs(StructList.newFactory(org.capnproto.test.Test.TestAllTypes.factory)));
     }
 
-    @org.junit.Test(expected=DecodeException.class)
+    @org.junit.jupiter.api.Test
     public void testInlineCompositeListIntOverflow2() throws DecodeException {
 
         byte[] bytes = new byte[]{0,0,0,0, 0,0,1,0, 1,0,0,0, 0x17,0,0,0, 0,0,0,-128, 16,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0};
@@ -612,45 +612,45 @@ public class EncodingTest {
         segment.order(ByteOrder.LITTLE_ENDIAN);
         MessageReader message = new MessageReader(new ByteBuffer[]{segment}, ReaderOptions.DEFAULT_READER_OPTIONS);
 
-        Test.TestAnyPointer.Reader root = message.getRoot(Test.TestAnyPointer.factory);
+        org.capnproto.test.Test.TestAnyPointer.Reader root = message.getRoot(org.capnproto.test.Test.TestAnyPointer.factory);
 
         MessageBuilder messageBuilder = new MessageBuilder();
-        Test.TestAnyPointer.Builder builderRoot = messageBuilder.initRoot(Test.TestAnyPointer.factory);
-        builderRoot.getAnyPointerField().setAs(Test.TestAnyPointer.factory, root);
+        org.capnproto.test.Test.TestAnyPointer.Builder builderRoot = messageBuilder.initRoot(org.capnproto.test.Test.TestAnyPointer.factory);
+        Assertions.assertThrows(DecodeException.class, () -> builderRoot.getAnyPointerField().setAs(org.capnproto.test.Test.TestAnyPointer.factory, root));
     }
 
-    @org.junit.Test(expected=DecodeException.class)
+    @org.junit.jupiter.api.Test
     public void testVoidListAmplification() throws DecodeException {
         MessageBuilder builder = new MessageBuilder();
-        builder.initRoot(Test.TestAnyPointer.factory).getAnyPointerField().initAs(PrimitiveList.Void.factory, 1 << 28);
+        builder.initRoot(org.capnproto.test.Test.TestAnyPointer.factory).getAnyPointerField().initAs(PrimitiveList.Void.factory, 1 << 28);
 
         ByteBuffer[] segments = builder.getSegmentsForOutput();
-        Assert.assertEquals(1, segments.length);
+        Assertions.assertEquals(1, segments.length);
 
         MessageReader reader = new MessageReader(segments, ReaderOptions.DEFAULT_READER_OPTIONS);
-        Test.TestAnyPointer.Reader root = reader.getRoot(Test.TestAnyPointer.factory);
-        root.getAnyPointerField().getAs(StructList.newFactory(Test.TestAllTypes.factory));
+        org.capnproto.test.Test.TestAnyPointer.Reader root = reader.getRoot(org.capnproto.test.Test.TestAnyPointer.factory);
+        Assertions.assertThrows(DecodeException.class, () -> root.getAnyPointerField().getAs(StructList.newFactory(org.capnproto.test.Test.TestAllTypes.factory)));
     }
 
-    @org.junit.Test(expected=DecodeException.class)
+    @org.junit.jupiter.api.Test
     public void testEmptyStructListAmplification() {
         MessageBuilder builder = new MessageBuilder();
-        builder.initRoot(Test.TestAnyPointer.factory).getAnyPointerField()
-                .initAs(StructList.newFactory(Test.TestEmptyStruct.factory), (1 << 29) - 1);
+        builder.initRoot(org.capnproto.test.Test.TestAnyPointer.factory).getAnyPointerField()
+                .initAs(StructList.newFactory(org.capnproto.test.Test.TestEmptyStruct.factory), (1 << 29) - 1);
 
         ByteBuffer[] segments = builder.getSegmentsForOutput();
-        Assert.assertEquals(1, segments.length);
+        Assertions.assertEquals(1, segments.length);
 
         MessageReader reader = new MessageReader(segments, ReaderOptions.DEFAULT_READER_OPTIONS);
-        Test.TestAnyPointer.Reader root = reader.getRoot(Test.TestAnyPointer.factory);
-        root.getAnyPointerField().getAs(StructList.newFactory(Test.TestAllTypes.factory));
+        org.capnproto.test.Test.TestAnyPointer.Reader root = reader.getRoot(org.capnproto.test.Test.TestAnyPointer.factory);
+        Assertions.assertThrows(DecodeException.class, () -> root.getAnyPointerField().getAs(StructList.newFactory(org.capnproto.test.Test.TestAllTypes.factory)));
     }
 
     // Test that we throw an exception on out-of-bounds list pointers.
     // Before v0.1.11, we were vulnerable to a cpu amplification attack:
     // reading an out-of-bounds pointer to list a huge number of elements of size BIT,
     // when read as a struct list, would return without error.
-    @org.junit.Test(expected=DecodeException.class)
+    @org.junit.jupiter.api.Test
     public void testListPointerOutOfBounds() throws DecodeException {
         byte[] bytes = new byte[]
                     {0,0,0,0, 0,0,1,0, // struct, one pointer
@@ -660,255 +660,255 @@ public class EncodingTest {
         MessageReader message = new MessageReader(new ByteBuffer[]{segment},
                                                   ReaderOptions.DEFAULT_READER_OPTIONS);
 
-        Test.TestAnyPointer.Reader root = message.getRoot(Test.TestAnyPointer.factory);
-        root.getAnyPointerField().getAs(StructList.newFactory(Test.TestAllTypes.factory));
+        org.capnproto.test.Test.TestAnyPointer.Reader root = message.getRoot(org.capnproto.test.Test.TestAnyPointer.factory);
+        Assertions.assertThrows(DecodeException.class, () -> root.getAnyPointerField().getAs(StructList.newFactory(org.capnproto.test.Test.TestAllTypes.factory)));
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testLongUint8List() {
       MessageBuilder message = new MessageBuilder();
-      Test.TestAllTypes.Builder allTypes = message.initRoot(Test.TestAllTypes.factory);
+      org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 28) + 1;
       PrimitiveList.Byte.Builder list = allTypes.initUInt8List(length);
-      Assert.assertEquals(list.size(), length);
+      Assertions.assertEquals(list.size(), length);
       list.set(length - 1, (byte)3);
-      Assert.assertEquals(list.get(length - 1), 3);
-      Assert.assertEquals(allTypes.asReader().getUInt8List().get(length - 1), 3);
+      Assertions.assertEquals(list.get(length - 1), 3);
+      Assertions.assertEquals(allTypes.asReader().getUInt8List().get(length - 1), 3);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testLongUint16List() {
       MessageBuilder message = new MessageBuilder();
-      Test.TestAllTypes.Builder allTypes = message.initRoot(Test.TestAllTypes.factory);
+      org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 27) + 1;
       PrimitiveList.Short.Builder list = allTypes.initUInt16List(length);
-      Assert.assertEquals(list.size(), length);
+      Assertions.assertEquals(list.size(), length);
       list.set(length - 1, (short)3);
-      Assert.assertEquals(list.get(length - 1), 3);
-      Assert.assertEquals(allTypes.asReader().getUInt16List().get(length - 1), 3);
+      Assertions.assertEquals(list.get(length - 1), 3);
+      Assertions.assertEquals(allTypes.asReader().getUInt16List().get(length - 1), 3);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testLongUint32List() {
       MessageBuilder message = new MessageBuilder();
-      Test.TestAllTypes.Builder allTypes = message.initRoot(Test.TestAllTypes.factory);
+      org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 26) + 1;
       PrimitiveList.Int.Builder list = allTypes.initUInt32List(length);
-      Assert.assertEquals(list.size(), length);
+      Assertions.assertEquals(list.size(), length);
       list.set(length - 1, 3);
-      Assert.assertEquals(list.get(length - 1), 3);
-      Assert.assertEquals(allTypes.asReader().getUInt32List().get(length - 1), 3);
+      Assertions.assertEquals(list.get(length - 1), 3);
+      Assertions.assertEquals(allTypes.asReader().getUInt32List().get(length - 1), 3);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testLongUint64List() {
       MessageBuilder message = new MessageBuilder();
-      Test.TestAllTypes.Builder allTypes = message.initRoot(Test.TestAllTypes.factory);
+      org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 25) + 1;
       PrimitiveList.Long.Builder list = allTypes.initUInt64List(length);
-      Assert.assertEquals(list.size(), length);
+      Assertions.assertEquals(list.size(), length);
       list.set(length - 1, 3);
-      Assert.assertEquals(list.get(length - 1), 3);
-      Assert.assertEquals(allTypes.asReader().getUInt64List().get(length - 1), 3);
+      Assertions.assertEquals(list.get(length - 1), 3);
+      Assertions.assertEquals(allTypes.asReader().getUInt64List().get(length - 1), 3);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testLongFloat32List() {
       MessageBuilder message = new MessageBuilder();
-      Test.TestAllTypes.Builder allTypes = message.initRoot(Test.TestAllTypes.factory);
+      org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 26) + 1;
       PrimitiveList.Float.Builder list = allTypes.initFloat32List(length);
-      Assert.assertEquals(list.size(), length);
+      Assertions.assertEquals(list.size(), length);
       list.set(length - 1, 3.14f);
-      Assert.assertEquals(list.get(length - 1), 3.14f, 0.0f);
-      Assert.assertEquals(allTypes.asReader().getFloat32List().get(length - 1), 3.14f, 0.0f);
+      Assertions.assertEquals(list.get(length - 1), 3.14f, 0.0f);
+      Assertions.assertEquals(allTypes.asReader().getFloat32List().get(length - 1), 3.14f, 0.0f);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testLongFloat64List() {
       MessageBuilder message = new MessageBuilder();
-      Test.TestAllTypes.Builder allTypes = message.initRoot(Test.TestAllTypes.factory);
+      org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 25) + 1;
       PrimitiveList.Double.Builder list = allTypes.initFloat64List(length);
-      Assert.assertEquals(list.size(), length);
+      Assertions.assertEquals(list.size(), length);
       list.set(length - 1, 3.14);
-      Assert.assertEquals(list.get(length - 1), 3.14, 0.0);
-      Assert.assertEquals(allTypes.asReader().getFloat64List().get(length - 1), 3.14, 0.0);
+      Assertions.assertEquals(list.get(length - 1), 3.14, 0.0);
+      Assertions.assertEquals(allTypes.asReader().getFloat64List().get(length - 1), 3.14, 0.0);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testLongStructList() {
       MessageBuilder message = new MessageBuilder();
-      Test.TestAllTypes.Builder allTypes = message.initRoot(Test.TestAllTypes.factory);
+      org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 21) + 1;
-      StructList.Builder<Test.TestAllTypes.Builder> list = allTypes.initStructList(length);
-      Assert.assertEquals(list.size(), length);
+      StructList.Builder<org.capnproto.test.Test.TestAllTypes.Builder> list = allTypes.initStructList(length);
+      Assertions.assertEquals(list.size(), length);
       list.get(length - 1).setUInt8Field((byte)3);
-      Assert.assertEquals(list.get(length - 1).getUInt8Field(), 3);
-      Assert.assertEquals(allTypes.asReader().getStructList().get(length - 1).getUInt8Field(), 3);
+      Assertions.assertEquals(list.get(length - 1).getUInt8Field(), 3);
+      Assertions.assertEquals(allTypes.asReader().getStructList().get(length - 1).getUInt8Field(), 3);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testLongTextList() {
       MessageBuilder message = new MessageBuilder();
-      Test.TestAllTypes.Builder allTypes = message.initRoot(Test.TestAllTypes.factory);
+      org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 25) + 1;
       TextList.Builder list = allTypes.initTextList(length);
-      Assert.assertEquals(list.size(), length);
+      Assertions.assertEquals(list.size(), length);
       list.set(length - 1, new Text.Reader("foo"));
-      Assert.assertEquals(list.get(length - 1).toString(), "foo");
-      Assert.assertEquals(allTypes.asReader().getTextList().get(length - 1).toString(), "foo");
+      Assertions.assertEquals(list.get(length - 1).toString(), "foo");
+      Assertions.assertEquals(allTypes.asReader().getTextList().get(length - 1).toString(), "foo");
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testLongListList() {
       MessageBuilder message = new MessageBuilder();
-      Test.TestLists.Builder root = message.initRoot(Test.TestLists.factory);
+      org.capnproto.test.Test.TestLists.Builder root = message.initRoot(org.capnproto.test.Test.TestLists.factory);
       int length = (1 << 25) + 1;
-      ListList.Builder<StructList.Builder<Test.TestAllTypes.Builder>> list = root.initStructListList(length);
-      Assert.assertEquals(list.size(), length);
+      ListList.Builder<StructList.Builder<org.capnproto.test.Test.TestAllTypes.Builder>> list = root.initStructListList(length);
+      Assertions.assertEquals(list.size(), length);
       list.init(length - 1, 3);
-      Assert.assertEquals(list.get(length - 1).size(), 3);
-      Assert.assertEquals(root.asReader().getStructListList().get(length - 1).size(), 3);
+      Assertions.assertEquals(list.get(length - 1).size(), 3);
+      Assertions.assertEquals(root.asReader().getStructListList().get(length - 1).size(), 3);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testStructSetters() {
       MessageBuilder builder = new MessageBuilder();
-      Test.TestAllTypes.Builder root = builder.initRoot(Test.TestAllTypes.factory);
+      org.capnproto.test.Test.TestAllTypes.Builder root = builder.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       TestUtil.initTestMessage(root);
 
       {
         MessageBuilder builder2 = new MessageBuilder();
-        builder2.setRoot(Test.TestAllTypes.factory, root.asReader());
-        TestUtil.checkTestMessage(builder2.getRoot(Test.TestAllTypes.factory));
+        builder2.setRoot(org.capnproto.test.Test.TestAllTypes.factory, root.asReader());
+        TestUtil.checkTestMessage(builder2.getRoot(org.capnproto.test.Test.TestAllTypes.factory));
       }
 
       {
         MessageBuilder builder2 = new MessageBuilder();
-        Test.TestAllTypes.Builder root2 = builder2.getRoot(Test.TestAllTypes.factory);
+        org.capnproto.test.Test.TestAllTypes.Builder root2 = builder2.getRoot(org.capnproto.test.Test.TestAllTypes.factory);
         root2.setStructField(root.asReader());
         TestUtil.checkTestMessage(root2.getStructField());
       }
 
       {
         MessageBuilder builder2 = new MessageBuilder();
-        Test.TestAnyPointer.Builder root2 = builder2.getRoot(Test.TestAnyPointer.factory);
-        root2.getAnyPointerField().setAs(Test.TestAllTypes.factory, root.asReader());
-        TestUtil.checkTestMessage(root2.getAnyPointerField().getAs(Test.TestAllTypes.factory));
+        org.capnproto.test.Test.TestAnyPointer.Builder root2 = builder2.getRoot(org.capnproto.test.Test.TestAnyPointer.factory);
+        root2.getAnyPointerField().setAs(org.capnproto.test.Test.TestAllTypes.factory, root.asReader());
+        TestUtil.checkTestMessage(root2.getAnyPointerField().getAs(org.capnproto.test.Test.TestAllTypes.factory));
       }
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testSerializedSize() {
       MessageBuilder builder = new MessageBuilder();
-      Test.TestAnyPointer.Builder root = builder.initRoot(Test.TestAnyPointer.factory);
+      org.capnproto.test.Test.TestAnyPointer.Builder root = builder.initRoot(org.capnproto.test.Test.TestAnyPointer.factory);
       root.getAnyPointerField().setAs(Text.factory, new Text.Reader("12345"));
 
       // one word for segment table, one for the root pointer,
       // one for the body of the TestAnyPointer struct,
       // and one for the body of the Text.
-      Assert.assertEquals(Serialize.computeSerializedSizeInWords(builder), 4);
+      Assertions.assertEquals(Serialize.computeSerializedSizeInWords(builder), 4);
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testImport() {
       MessageBuilder builder = new MessageBuilder();
       org.capnproto.testimport.TestImport.Foo.Builder root = builder.initRoot(org.capnproto.testimport.TestImport.Foo.factory);
-      Test.TestAllTypes.Builder field = root.initImportedStruct();
+      org.capnproto.test.Test.TestAllTypes.Builder field = root.initImportedStruct();
       TestUtil.initTestMessage(field);
       TestUtil.checkTestMessage(field);
       TestUtil.checkTestMessage(field.asReader());
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testGenericMap() {
       MessageBuilder builder = new MessageBuilder();
-      Test.GenericMap.Factory<Text.Builder, Text.Reader, Test.TestAllTypes.Builder, Test.TestAllTypes.Reader> mapFactory
-        = Test.GenericMap.newFactory(Text.factory, Test.TestAllTypes.factory);
+      org.capnproto.test.Test.GenericMap.Factory<Text.Builder, Text.Reader, org.capnproto.test.Test.TestAllTypes.Builder, org.capnproto.test.Test.TestAllTypes.Reader> mapFactory
+        = org.capnproto.test.Test.GenericMap.newFactory(Text.factory, org.capnproto.test.Test.TestAllTypes.factory);
 
-      StructList.Factory<Test.GenericMap.Entry.Builder<Text.Builder, Test.TestAllTypes.Builder>,
-                         Test.GenericMap.Entry.Reader<Text.Reader, Test.TestAllTypes.Reader>> entryFactory
-        = StructList.newFactory(Test.GenericMap.Entry.newFactory(Text.factory, Test.TestAllTypes.factory));
+      StructList.Factory<org.capnproto.test.Test.GenericMap.Entry.Builder<Text.Builder, org.capnproto.test.Test.TestAllTypes.Builder>,
+                         org.capnproto.test.Test.GenericMap.Entry.Reader<Text.Reader, org.capnproto.test.Test.TestAllTypes.Reader>> entryFactory
+        = StructList.newFactory(org.capnproto.test.Test.GenericMap.Entry.newFactory(Text.factory, org.capnproto.test.Test.TestAllTypes.factory));
 
-      Test.GenericMap.Builder<Text.Builder, Test.TestAllTypes.Builder> root = builder.initRoot(mapFactory);
+      org.capnproto.test.Test.GenericMap.Builder<Text.Builder, org.capnproto.test.Test.TestAllTypes.Builder> root = builder.initRoot(mapFactory);
 
       {
-        StructList.Builder<Test.GenericMap.Entry.Builder<Text.Builder, Test.TestAllTypes.Builder>> entries = root.initEntries(entryFactory, 3);
+        StructList.Builder<org.capnproto.test.Test.GenericMap.Entry.Builder<Text.Builder, org.capnproto.test.Test.TestAllTypes.Builder>> entries = root.initEntries(entryFactory, 3);
 
-        Test.GenericMap.Entry.Builder<Text.Builder, Test.TestAllTypes.Builder> entry0 = entries.get(0);
+        org.capnproto.test.Test.GenericMap.Entry.Builder<Text.Builder, org.capnproto.test.Test.TestAllTypes.Builder> entry0 = entries.get(0);
         entry0.setKey(Text.factory, new Text.Reader("foo"));
-        Test.TestAllTypes.Builder value0 = entry0.initValue();
+        org.capnproto.test.Test.TestAllTypes.Builder value0 = entry0.initValue();
         value0.setInt64Field(101);
 
-        Test.GenericMap.Entry.Builder<Text.Builder, Test.TestAllTypes.Builder> entry1 = entries.get(1);
+        org.capnproto.test.Test.GenericMap.Entry.Builder<Text.Builder, org.capnproto.test.Test.TestAllTypes.Builder> entry1 = entries.get(1);
         entry1.setKey(Text.factory, new Text.Reader("bar"));
-        Test.TestAllTypes.Builder value1 = entry1.initValue();
+        org.capnproto.test.Test.TestAllTypes.Builder value1 = entry1.initValue();
         value1.setInt64Field(202);
 
-        Test.GenericMap.Entry.Builder<Text.Builder, Test.TestAllTypes.Builder> entry2 = entries.get(2);
+        org.capnproto.test.Test.GenericMap.Entry.Builder<Text.Builder, org.capnproto.test.Test.TestAllTypes.Builder> entry2 = entries.get(2);
         entry2.setKey(Text.factory, new Text.Reader("baz"));
-        Test.TestAllTypes.Builder value2 = entry2.initValue();
+        org.capnproto.test.Test.TestAllTypes.Builder value2 = entry2.initValue();
         value2.setInt64Field(303);
       }
 
       {
-         StructList.Reader<Test.GenericMap.Entry.Reader<Text.Reader, Test.TestAllTypes.Reader>> entries =
+         StructList.Reader<org.capnproto.test.Test.GenericMap.Entry.Reader<Text.Reader, org.capnproto.test.Test.TestAllTypes.Reader>> entries =
            root.asReader(mapFactory).getEntries(entryFactory);
 
-         Test.GenericMap.Entry.Reader<Text.Reader, Test.TestAllTypes.Reader> entry0 = entries.get(0);
-         Assert.assertEquals(entry0.getKey().toString(), "foo");
-         Assert.assertEquals(entry0.getValue().getInt64Field(), 101);
+         org.capnproto.test.Test.GenericMap.Entry.Reader<Text.Reader, org.capnproto.test.Test.TestAllTypes.Reader> entry0 = entries.get(0);
+         Assertions.assertEquals(entry0.getKey().toString(), "foo");
+         Assertions.assertEquals(entry0.getValue().getInt64Field(), 101);
 
-         Test.GenericMap.Entry.Reader<Text.Reader, Test.TestAllTypes.Reader> entry1 = entries.get(1);
-         Assert.assertEquals(entry1.getKey().toString(), "bar");
-         Assert.assertEquals(entry1.getValue().getInt64Field(), 202);
+         org.capnproto.test.Test.GenericMap.Entry.Reader<Text.Reader, org.capnproto.test.Test.TestAllTypes.Reader> entry1 = entries.get(1);
+         Assertions.assertEquals(entry1.getKey().toString(), "bar");
+         Assertions.assertEquals(entry1.getValue().getInt64Field(), 202);
 
-         Test.GenericMap.Entry.Reader<Text.Reader, Test.TestAllTypes.Reader> entry2 = entries.get(2);
-         Assert.assertEquals(entry2.getKey().toString(), "baz");
-         Assert.assertEquals(entry2.getValue().getInt64Field(), 303);
+         org.capnproto.test.Test.GenericMap.Entry.Reader<Text.Reader, org.capnproto.test.Test.TestAllTypes.Reader> entry2 = entries.get(2);
+         Assertions.assertEquals(entry2.getKey().toString(), "baz");
+         Assertions.assertEquals(entry2.getValue().getInt64Field(), 303);
       }
     }
 
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void testSetWithCaveats() {
       MessageBuilder builder = new MessageBuilder();
-      Test.TestAllTypes.Builder root = builder.initRoot(Test.TestAllTypes.factory);
-      StructList.Builder<Test.TestAllTypes.Builder> list = root.initStructList(2);
+      org.capnproto.test.Test.TestAllTypes.Builder root = builder.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
+      StructList.Builder<org.capnproto.test.Test.TestAllTypes.Builder> list = root.initStructList(2);
 
       {
         MessageBuilder message1 = new MessageBuilder();
-        Test.TestAllTypes.Builder root1 = message1.initRoot(Test.TestAllTypes.factory);
+        org.capnproto.test.Test.TestAllTypes.Builder root1 = message1.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
         root1.setInt8Field((byte)11);
-        list.setWithCaveats(Test.TestAllTypes.factory, 0, root1.asReader());
+        list.setWithCaveats(org.capnproto.test.Test.TestAllTypes.factory, 0, root1.asReader());
       }
 
       {
         MessageBuilder message2 = new MessageBuilder();
-        Test.TestAllTypes.Builder root2 = message2.initRoot(Test.TestAllTypes.factory);
+        org.capnproto.test.Test.TestAllTypes.Builder root2 = message2.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
         TestUtil.initTestMessage(root2);
-        list.setWithCaveats(Test.TestAllTypes.factory, 1, root2.asReader());
+        list.setWithCaveats(org.capnproto.test.Test.TestAllTypes.factory, 1, root2.asReader());
       }
 
-      StructList.Reader<Test.TestAllTypes.Reader> listReader = list.asReader(Test.TestAllTypes.factory);
-      Assert.assertEquals(listReader.get(0).getInt8Field(), 11);
+      StructList.Reader<org.capnproto.test.Test.TestAllTypes.Reader> listReader = list.asReader(org.capnproto.test.Test.TestAllTypes.factory);
+      Assertions.assertEquals(listReader.get(0).getInt8Field(), 11);
       TestUtil.checkTestMessage(listReader.get(1));
   }
 
-  @org.junit.Test
+  @org.junit.jupiter.api.Test
   public void testCopyAnyPointer() {
       MessageBuilder message1 = new MessageBuilder();
-      Test.TestAllTypes.Builder root1 = message1.initRoot(Test.TestAllTypes.factory);
+      org.capnproto.test.Test.TestAllTypes.Builder root1 = message1.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       TestUtil.initTestMessage(root1);
 
       MessageBuilder message2 = new MessageBuilder();
       AnyPointer.Builder root2 = message2.initRoot(AnyPointer.factory);
       root2.setAs(AnyPointer.factory, message1.getRoot(AnyPointer.factory).asReader());
 
-      TestUtil.checkTestMessage(root2.getAs(Test.TestAllTypes.factory));
+      TestUtil.checkTestMessage(root2.getAs(org.capnproto.test.Test.TestAllTypes.factory));
   }
 
-  @org.junit.Test
+  @org.junit.jupiter.api.Test
   public void testZeroPointerUnderflow() throws DecodeException {
       byte[] bytes = new byte[8 + 8 * 65535];
       bytes[4] = -1;
@@ -920,40 +920,40 @@ public class EncodingTest {
       segment.order(ByteOrder.LITTLE_ENDIAN);
       MessageReader message1 = new MessageReader(new ByteBuffer[]{segment},
                                                 ReaderOptions.DEFAULT_READER_OPTIONS);
-      Test.TestAnyPointer.Reader message1RootReader = message1.getRoot(Test.TestAnyPointer.factory);
+      org.capnproto.test.Test.TestAnyPointer.Reader message1RootReader = message1.getRoot(org.capnproto.test.Test.TestAnyPointer.factory);
 
       MessageBuilder message2Builder =
           new MessageBuilder(3 * 65535); // ample space to avoid far pointers
-      Test.TestAnyPointer.Builder message2RootBuilder =
-          message2Builder.getRoot(Test.TestAnyPointer.factory);
+      org.capnproto.test.Test.TestAnyPointer.Builder message2RootBuilder =
+          message2Builder.getRoot(org.capnproto.test.Test.TestAnyPointer.factory);
 
       // Copy the struct that has the sentinel data.
-      message2RootBuilder.getAnyPointerField().setAs(Test.TestAnyPointer.factory, message1RootReader);
+      message2RootBuilder.getAnyPointerField().setAs(org.capnproto.test.Test.TestAnyPointer.factory, message1RootReader);
 
       // Now clear the struct pointer.
       message2RootBuilder.getAnyPointerField().clear();
 
       java.nio.ByteBuffer[] outputSegments = message2Builder.getSegmentsForOutput();
-      Assert.assertEquals(1, outputSegments.length);
-      Assert.assertEquals(0L, outputSegments[0].getLong(8)); // null because cleared
+      Assertions.assertEquals(1, outputSegments.length);
+      Assertions.assertEquals(0L, outputSegments[0].getLong(8)); // null because cleared
 
-      Assert.assertEquals(16 + 8 * 65535, outputSegments[0].limit());
+      Assertions.assertEquals(16 + 8 * 65535, outputSegments[0].limit());
       for (int ii = 0; ii < 65535; ++ii) {
           // All of the data should have been cleared.
-          Assert.assertEquals(0L, outputSegments[0].getLong((2 + ii) * 8));
+          Assertions.assertEquals(0L, outputSegments[0].getLong((2 + ii) * 8));
       }
     }
 
     // This test fails on https://github.com/capnproto/capnproto-java/pull/143,
     // illustrating why https://github.com/capnproto/capnproto-java/commit/28ab5ced
     // is needed.
-    @org.junit.Test
+    @org.junit.jupiter.api.Test
     public void setDataPointer() {
         MessageBuilder message1 = new MessageBuilder();
-        Test.TestAllTypes.Builder allTypes1 = message1.initRoot(Test.TestAllTypes.factory);
+        org.capnproto.test.Test.TestAllTypes.Builder allTypes1 = message1.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
         TestUtil.initTestMessage(allTypes1);
         MessageBuilder message2 = new MessageBuilder();
-        Test.TestAllTypes.Builder allTypes2 = message2.initRoot(Test.TestAllTypes.factory);
+        org.capnproto.test.Test.TestAllTypes.Builder allTypes2 = message2.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
         TestUtil.initTestMessage(allTypes2);
 
         allTypes1.setDataField(allTypes2.asReader().getDataField());

--- a/compiler/src/test/java/org/capnproto/test/EncodingTest.java
+++ b/compiler/src/test/java/org/capnproto/test/EncodingTest.java
@@ -3,13 +3,21 @@ package org.capnproto.test;
 import org.capnproto.*;
 import org.capnproto.Void;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class EncodingTest {
-    @org.junit.jupiter.api.Test
+    @Test
     public void testAllTypes() {
         MessageBuilder message = new MessageBuilder();
         org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
@@ -18,7 +26,7 @@ public class EncodingTest {
         TestUtil.checkTestMessage(allTypes.asReader());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testAllTypesMultiSegment() {
         MessageBuilder message = new MessageBuilder(5, BuilderArena.AllocationStrategy.FIXED_SIZE);
         org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
@@ -28,7 +36,7 @@ public class EncodingTest {
         TestUtil.checkTestMessage(allTypes.asReader());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testSetters() {
         MessageBuilder message = new MessageBuilder();
         org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
@@ -44,7 +52,7 @@ public class EncodingTest {
         TestUtil.checkTestMessage(reader);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testZeroing() {
         MessageBuilder message = new MessageBuilder();
         org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
@@ -68,12 +76,12 @@ public class EncodingTest {
         ByteBuffer[] segments = message.getSegmentsForOutput();
         for (ByteBuffer segment : segments) {
             for (int j = 0; j < segment.limit(); j++) {
-                Assertions.assertEquals(segment.get(j), 0);
+                assertEquals(segment.get(j), 0);
             }
         }
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testDoubleFarPointers() throws IOException {
         byte[] bytes = new byte[]{2, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0,
                 6, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0,
@@ -83,12 +91,12 @@ public class EncodingTest {
         MessageReader message = org.capnproto.Serialize.read(input);
         org.capnproto.test.Test.TestAllTypes.Reader root = message.getRoot(org.capnproto.test.Test.TestAllTypes.factory);
 
-        Assertions.assertTrue(root.getBoolField());
-        Assertions.assertEquals(root.getInt8Field(), 7);
-        Assertions.assertEquals(root.getInt16Field(), 32767);
+        assertTrue(root.getBoolField());
+        assertEquals(root.getInt8Field(), 7);
+        assertEquals(root.getInt16Field(), 32767);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testUpgradeStruct() {
       MessageBuilder builder = new MessageBuilder();
       org.capnproto.test.Test.TestAnyPointer.Builder root = builder.initRoot(org.capnproto.test.Test.TestAnyPointer.factory);
@@ -104,15 +112,15 @@ public class EncodingTest {
 
       {
         org.capnproto.test.Test.TestNewVersion.Reader newVersion = root.getAnyPointerField().asReader().getAs(org.capnproto.test.Test.TestNewVersion.factory);
-        Assertions.assertEquals(newVersion.getOld1(), 123);
-        Assertions.assertEquals(newVersion.getOld2().toString(), "foo");
-        Assertions.assertEquals(newVersion.getNew2().toString(),  "baz");
-        Assertions.assertEquals(newVersion.hasNew2(), false);
-        Assertions.assertEquals(newVersion.hasNew3(), false);
+        assertEquals(newVersion.getOld1(), 123);
+        assertEquals(newVersion.getOld2().toString(), "foo");
+        assertEquals(newVersion.getNew2().toString(),  "baz");
+        assertEquals(newVersion.hasNew2(), false);
+        assertEquals(newVersion.hasNew3(), false);
       }
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testUpgradeStructReadAsOld() {
       MessageBuilder builder = new MessageBuilder();
       org.capnproto.test.Test.TestAnyPointer.Builder root = builder.initRoot(org.capnproto.test.Test.TestAnyPointer.factory);
@@ -134,17 +142,17 @@ public class EncodingTest {
 
       {
         org.capnproto.test.Test.TestOldVersion.Reader oldVersion = root.getAnyPointerField().asReader().getAs(org.capnproto.test.Test.TestOldVersion.factory);
-        Assertions.assertEquals(oldVersion.getOld1(), 123);
-        Assertions.assertEquals(oldVersion.getOld2().toString(), "foo");
+        assertEquals(oldVersion.getOld1(), 123);
+        assertEquals(oldVersion.getOld2().toString(), "foo");
 
         TextList.Reader names = oldVersion.getOld4();
-        Assertions.assertEquals(names.size(), 2);
-        Assertions.assertEquals("alice", names.get(0).toString());
-        Assertions.assertEquals("bob", names.get(1).toString());
+        assertEquals(names.size(), 2);
+        assertEquals("alice", names.get(0).toString());
+        assertEquals("bob", names.get(1).toString());
       }
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testUpgradeStructInBuilder() {
         MessageBuilder builder = new MessageBuilder();
         org.capnproto.test.Test.TestAnyPointer.Builder root = builder.initRoot(org.capnproto.test.Test.TestAnyPointer.factory);
@@ -159,13 +167,13 @@ public class EncodingTest {
         }
         {
             org.capnproto.test.Test.TestNewVersion.Builder newVersion = root.getAnyPointerField().getAs(org.capnproto.test.Test.TestNewVersion.factory);
-            Assertions.assertEquals(newVersion.getOld1(), 123);
-            Assertions.assertEquals(newVersion.getOld2().toString(), "foo");
-            Assertions.assertEquals(newVersion.getNew1(), 987);
-            Assertions.assertEquals(newVersion.getNew2().toString(), "baz");
+            assertEquals(newVersion.getOld1(), 123);
+            assertEquals(newVersion.getOld2().toString(), "foo");
+            assertEquals(newVersion.getNew1(), 987);
+            assertEquals(newVersion.getNew2().toString(), "baz");
             org.capnproto.test.Test.TestNewVersion.Builder sub = newVersion.getOld3();
-            Assertions.assertEquals(sub.getOld1(), 456);
-            Assertions.assertEquals(sub.getOld2().toString(), "bar");
+            assertEquals(sub.getOld1(), 456);
+            assertEquals(sub.getOld2().toString(), "bar");
 
             newVersion.setOld1(234);
             newVersion.setOld2("qux");
@@ -174,12 +182,12 @@ public class EncodingTest {
         }
         {
             org.capnproto.test.Test.TestOldVersion.Builder oldVersion = root.getAnyPointerField().getAs(org.capnproto.test.Test.TestOldVersion.factory);
-            Assertions.assertEquals(oldVersion.getOld1(), 234);
-            Assertions.assertEquals(oldVersion.getOld2().toString(), "qux");
+            assertEquals(oldVersion.getOld1(), 234);
+            assertEquals(oldVersion.getOld2().toString(), "qux");
         }
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testStructListUpgrade() {
         MessageBuilder message = new MessageBuilder();
         org.capnproto.test.Test.TestAnyPointer.Builder root = message.initRoot(org.capnproto.test.Test.TestAnyPointer.factory);
@@ -193,16 +201,16 @@ public class EncodingTest {
         }
         {
             StructList.Reader<org.capnproto.test.Test.TestOldVersion.Reader> olds = any.asReader().getAs(org.capnproto.test.Test.TestOldVersion.listFactory);
-            Assertions.assertEquals(olds.get(0).getOld1(), 123);
-            Assertions.assertEquals(olds.get(1).getOld1(), 456);
-            Assertions.assertEquals(olds.get(2).getOld1(), 789);
+            assertEquals(olds.get(0).getOld1(), 123);
+            assertEquals(olds.get(1).getOld1(), 456);
+            assertEquals(olds.get(2).getOld1(), 789);
         }
         {
             StructList.Builder<org.capnproto.test.Test.TestOldVersion.Builder> olds = any.getAs(org.capnproto.test.Test.TestOldVersion.listFactory);
-            Assertions.assertEquals(olds.size(), 3);
-            Assertions.assertEquals(olds.get(0).getOld1(), 123);
-            Assertions.assertEquals(olds.get(1).getOld1(), 456);
-            Assertions.assertEquals(olds.get(2).getOld1(), 789);
+            assertEquals(olds.size(), 3);
+            assertEquals(olds.get(0).getOld1(), 123);
+            assertEquals(olds.get(1).getOld1(), 456);
+            assertEquals(olds.get(2).getOld1(), 789);
 
             olds.get(0).setOld2("zero");
             olds.get(1).setOld2("one");
@@ -210,19 +218,19 @@ public class EncodingTest {
         }
         {
             StructList.Builder<org.capnproto.test.Test.TestNewVersion.Builder> news = any.getAs(org.capnproto.test.Test.TestNewVersion.listFactory);
-            Assertions.assertEquals(news.size(), 3);
-            Assertions.assertEquals(news.get(0).getOld1(), 123);
-            Assertions.assertEquals(news.get(0).getOld2().toString(), "zero");
+            assertEquals(news.size(), 3);
+            assertEquals(news.get(0).getOld1(), 123);
+            assertEquals(news.get(0).getOld2().toString(), "zero");
 
-            Assertions.assertEquals(news.get(1).getOld1(), 456);
-            Assertions.assertEquals(news.get(1).getOld2().toString(), "one");
+            assertEquals(news.get(1).getOld1(), 456);
+            assertEquals(news.get(1).getOld2().toString(), "one");
 
-            Assertions.assertEquals(news.get(2).getOld1(), 789);
-            Assertions.assertEquals(news.get(2).getOld2().toString(), "two");
+            assertEquals(news.get(2).getOld1(), 789);
+            assertEquals(news.get(2).getOld2().toString(), "two");
         }
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testStructListUpgradeDoubleFar() {
       byte[] bytes = new byte[]{
             1,0,0,0,0x1f,0,0,0, // list, inline composite, 3 words
@@ -238,9 +246,9 @@ public class EncodingTest {
 
       StructList.Reader<org.capnproto.test.Test.TestOldVersion.Reader> oldVersion = messageReader.getRoot(StructList.newFactory(org.capnproto.test.Test.TestOldVersion.factory));
 
-      Assertions.assertEquals(oldVersion.size(), 1);
-      Assertions.assertEquals(oldVersion.get(0).getOld1(), 91);
-      Assertions.assertEquals(oldVersion.get(0).getOld2().toString(), "hello!!");
+      assertEquals(oldVersion.size(), 1);
+      assertEquals(oldVersion.get(0).getOld1(), 91);
+      assertEquals(oldVersion.get(0).getOld2().toString(), "hello!!");
 
       // Make the first segment exactly large enough to fit the original message.
       // This leaves no room for a far pointer landing pad in the first segment.
@@ -248,91 +256,91 @@ public class EncodingTest {
       message.setRoot(StructList.newFactory(org.capnproto.test.Test.TestOldVersion.factory), oldVersion);
 
       ByteBuffer[] segments = message.getSegmentsForOutput();
-      Assertions.assertEquals(segments.length, 1);
-      Assertions.assertEquals(segments[0].limit(), 6 * 8);
+      assertEquals(segments.length, 1);
+      assertEquals(segments[0].limit(), 6 * 8);
 
       StructList.Builder<org.capnproto.test.Test.TestNewVersion.Builder> newVersion =
         message.getRoot(new StructList.Factory<org.capnproto.test.Test.TestNewVersion.Builder, org.capnproto.test.Test.TestNewVersion.Reader>(org.capnproto.test.Test.TestNewVersion.factory));
-      Assertions.assertEquals(newVersion.size(), 1);
-      Assertions.assertEquals(newVersion.get(0).getOld1(), 91);
-      Assertions.assertEquals(newVersion.get(0).getOld2().toString(), "hello!!");
+      assertEquals(newVersion.size(), 1);
+      assertEquals(newVersion.get(0).getOld1(), 91);
+      assertEquals(newVersion.get(0).getOld2().toString(), "hello!!");
 
       ByteBuffer[] segments1 = message.getSegmentsForOutput();
-      Assertions.assertEquals(segments[0].limit(), 6 * 8);
+      assertEquals(segments[0].limit(), 6 * 8);
       for (int ii = 8; ii < (5 * 8) - 1; ++ii) {
         // Check the the old list, including the tag, was zeroed.
-        Assertions.assertEquals(segments[0].get(ii), 0);
+        assertEquals(segments[0].get(ii), 0);
       }
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testListBuilderAsReader() {
       MessageBuilder message = new MessageBuilder();
       org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
 
       allTypes.initVoidList(10);
-      Assertions.assertEquals(allTypes.getVoidList().asReader().size(), 10);
+      assertEquals(allTypes.getVoidList().asReader().size(), 10);
 
       PrimitiveList.Boolean.Builder boolList = allTypes.initBoolList(7);
       boolList.set(3, true);
       PrimitiveList.Boolean.Reader boolListReader = boolList.asReader();
-      Assertions.assertEquals(boolListReader.size(), 7);
-      Assertions.assertEquals(boolListReader.get(0), false);
-      Assertions.assertEquals(boolListReader.get(1), false);
-      Assertions.assertEquals(boolListReader.get(2), false);
-      Assertions.assertEquals(boolListReader.get(3), true);
-      Assertions.assertEquals(boolListReader.get(4), false);
+      assertEquals(boolListReader.size(), 7);
+      assertEquals(boolListReader.get(0), false);
+      assertEquals(boolListReader.get(1), false);
+      assertEquals(boolListReader.get(2), false);
+      assertEquals(boolListReader.get(3), true);
+      assertEquals(boolListReader.get(4), false);
 
       PrimitiveList.Byte.Builder int8List = allTypes.initInt8List(9);
       int8List.set(4, (byte)100);
       int8List.set(8, (byte)11);
       PrimitiveList.Byte.Reader int8ListReader = int8List.asReader();
-      Assertions.assertEquals(int8ListReader.size(), 9);
-      Assertions.assertEquals(int8ListReader.get(0), 0);
-      Assertions.assertEquals(int8ListReader.get(4), 100);
-      Assertions.assertEquals(int8ListReader.get(8), 11);
+      assertEquals(int8ListReader.size(), 9);
+      assertEquals(int8ListReader.get(0), 0);
+      assertEquals(int8ListReader.get(4), 100);
+      assertEquals(int8ListReader.get(8), 11);
 
       PrimitiveList.Short.Builder int16List = allTypes.initInt16List(2);
       int16List.set(0, (short)1);
       PrimitiveList.Short.Reader int16ListReader = int16List.asReader();
-      Assertions.assertEquals(int16ListReader.size(), 2);
-      Assertions.assertEquals(int16ListReader.get(0), 1);
-      Assertions.assertEquals(int16ListReader.get(1), 0);
+      assertEquals(int16ListReader.size(), 2);
+      assertEquals(int16ListReader.get(0), 1);
+      assertEquals(int16ListReader.get(1), 0);
 
       // TODO other primitive lists
 
       TextList.Builder textList = allTypes.initTextList(1);
       textList.set(0, new Text.Reader("abcdefg"));
       TextList.Reader textListReader = textList.asReader();
-      Assertions.assertEquals(textListReader.size(), 1);
-      Assertions.assertEquals(textListReader.get(0).toString(), "abcdefg");
+      assertEquals(textListReader.size(), 1);
+      assertEquals(textListReader.get(0).toString(), "abcdefg");
 
       DataList.Builder dataList = allTypes.initDataList(1);
       dataList.set(0, new Data.Reader(new byte[]{1,2,3,4}));
       DataList.Reader dataListReader = dataList.asReader();
-      Assertions.assertEquals(dataListReader.size(), 1);
-      Assertions.assertTrue(java.util.Arrays.equals(dataListReader.get(0).toArray(), new byte[]{1,2,3,4}));
+      assertEquals(dataListReader.size(), 1);
+      assertTrue(java.util.Arrays.equals(dataListReader.get(0).toArray(), new byte[]{1,2,3,4}));
 
       StructList.Builder<org.capnproto.test.Test.TestAllTypes.Builder> structList = allTypes.initStructList(2);
       structList.get(0).setInt8Field((byte)5);
       structList.get(1).setInt8Field((byte)9);
       StructList.Reader<org.capnproto.test.Test.TestAllTypes.Reader> structListReader = structList.asReader(org.capnproto.test.Test.TestAllTypes.factory);
-      Assertions.assertEquals(structListReader.size(), 2);
-      Assertions.assertEquals(structListReader.get(0).getInt8Field(), 5);
-      Assertions.assertEquals(structListReader.get(1).getInt8Field(), 9);
+      assertEquals(structListReader.size(), 2);
+      assertEquals(structListReader.get(0).getInt8Field(), 5);
+      assertEquals(structListReader.get(1).getInt8Field(), 9);
 
       EnumList.Builder<org.capnproto.test.Test.TestEnum> enumList = allTypes.initEnumList(3);
       enumList.set(0, org.capnproto.test.Test.TestEnum.FOO);
       enumList.set(1, org.capnproto.test.Test.TestEnum.BAR);
       enumList.set(2, org.capnproto.test.Test.TestEnum.BAZ);
       EnumList.Reader<org.capnproto.test.Test.TestEnum> enumListReader = enumList.asReader();
-      Assertions.assertEquals(enumListReader.size(), 3);
-      Assertions.assertEquals(enumListReader.get(0), org.capnproto.test.Test.TestEnum.FOO);
-      Assertions.assertEquals(enumListReader.get(1), org.capnproto.test.Test.TestEnum.BAR);
-      Assertions.assertEquals(enumListReader.get(2), org.capnproto.test.Test.TestEnum.BAZ);
+      assertEquals(enumListReader.size(), 3);
+      assertEquals(enumListReader.get(0), org.capnproto.test.Test.TestEnum.FOO);
+      assertEquals(enumListReader.get(1), org.capnproto.test.Test.TestEnum.BAR);
+      assertEquals(enumListReader.get(2), org.capnproto.test.Test.TestEnum.BAZ);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testNestedListBuilderAsReader() {
       MessageBuilder builder = new MessageBuilder();
       org.capnproto.test.Test.TestLists.Builder root = builder.initRoot(org.capnproto.test.Test.TestLists.factory);
@@ -348,19 +356,19 @@ public class EncodingTest {
 
       ListList.Reader<StructList.Reader<org.capnproto.test.Test.TestAllTypes.Reader>> structListListReader =
         structListList.asReader(StructList.newFactory(org.capnproto.test.Test.TestAllTypes.factory));
-      Assertions.assertEquals(structListListReader.size(), 3);
+      assertEquals(structListListReader.size(), 3);
       StructList.Reader<org.capnproto.test.Test.TestAllTypes.Reader> structList0Reader = structListListReader.get(0);
-      Assertions.assertEquals(structList0Reader.size(), 1);
-      Assertions.assertEquals(structList0Reader.get(0).getInt16Field(), 1);
-      Assertions.assertEquals(structListListReader.get(1).size(), 0);
+      assertEquals(structList0Reader.size(), 1);
+      assertEquals(structList0Reader.get(0).getInt16Field(), 1);
+      assertEquals(structListListReader.get(1).size(), 0);
       StructList.Reader<org.capnproto.test.Test.TestAllTypes.Reader> structList2Reader = structListListReader.get(2);
-      Assertions.assertEquals(structList2Reader.size(), 3);
-      Assertions.assertEquals(structList2Reader.get(0).getInt16Field(), 22);
-      Assertions.assertEquals(structList2Reader.get(1).getInt16Field(), 333);
-      Assertions.assertEquals(structList2Reader.get(2).getInt16Field(), 4444);
+      assertEquals(structList2Reader.size(), 3);
+      assertEquals(structList2Reader.get(0).getInt16Field(), 22);
+      assertEquals(structList2Reader.get(1).getInt16Field(), 333);
+      assertEquals(structList2Reader.get(2).getInt16Field(), 4444);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testGenerics() {
         MessageBuilder message = new MessageBuilder();
 
@@ -382,13 +390,13 @@ public class EncodingTest {
             root.asReader(org.capnproto.test.Test.TestGenerics.newFactory(org.capnproto.test.Test.TestAllTypes.factory, Text.factory));
         TestUtil.checkTestMessage(rootReader.getFoo());
         org.capnproto.test.Test.TestGenerics.Builder<Text.Builder, PrimitiveList.Byte.Builder> dubReader = root.getDub();
-        Assertions.assertEquals(dubReader.getFoo().toString(), "Hello");
+        assertEquals(dubReader.getFoo().toString(), "Hello");
         PrimitiveList.Byte.Builder barReader = dubReader.getBar();
-        Assertions.assertEquals(1, barReader.size());
-        Assertions.assertEquals(11, barReader.get(0));
+        assertEquals(1, barReader.size());
+        assertEquals(11, barReader.get(0));
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testUseGenerics() {
         MessageBuilder message = new MessageBuilder();
         org.capnproto.test.Test.TestUseGenerics.Builder root = message.initRoot(org.capnproto.test.Test.TestUseGenerics.factory);
@@ -401,10 +409,10 @@ public class EncodingTest {
             root.setUnspecified(factory2, root2.asReader(factory2));
         }
 
-        Assertions.assertEquals("foobar", root.getUnspecified().getDub().getFoo().toString());
+        assertEquals("foobar", root.getUnspecified().getDub().getFoo().toString());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testDefaults() {
         MessageBuilder message = new MessageBuilder();
         org.capnproto.test.Test.TestDefaults.Builder defaults = message.initRoot(org.capnproto.test.Test.TestDefaults.factory);
@@ -414,19 +422,19 @@ public class EncodingTest {
         TestUtil.checkSettedDefaultMessage(defaults.asReader());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testUnions() {
       MessageBuilder builder = new MessageBuilder();
       org.capnproto.test.Test.TestUnion.Builder root = builder.initRoot(org.capnproto.test.Test.TestUnion.factory);
       org.capnproto.test.Test.TestUnion.Union0.Builder u0 = root.initUnion0();
       u0.initU0f1sp(10);
-      Assertions.assertEquals(u0.which(), org.capnproto.test.Test.TestUnion.Union0.Which.U0F1SP);
+      assertEquals(u0.which(), org.capnproto.test.Test.TestUnion.Union0.Which.U0F1SP);
 
       u0.initPrimitiveList(10);
-      Assertions.assertEquals(u0.which(), org.capnproto.test.Test.TestUnion.Union0.Which.PRIMITIVE_LIST);
+      assertEquals(u0.which(), org.capnproto.test.Test.TestUnion.Union0.Which.PRIMITIVE_LIST);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testGroups() {
         MessageBuilder builder = new MessageBuilder();
         org.capnproto.test.Test.TestGroups.Builder root = builder.initRoot(org.capnproto.test.Test.TestGroups.factory);
@@ -436,9 +444,9 @@ public class EncodingTest {
             foo.setGrault(123456789012345L);
             foo.setGarply(new Text.Reader("foobar"));
 
-            Assertions.assertEquals(12345678, foo.getCorge());
-            Assertions.assertEquals(123456789012345L, foo.getGrault());
-            Assertions.assertEquals("foobar", foo.getGarply().toString());
+            assertEquals(12345678, foo.getCorge());
+            assertEquals(123456789012345L, foo.getGrault());
+            assertEquals("foobar", foo.getGarply().toString());
         }
         {
             org.capnproto.test.Test.TestGroups.Groups.Bar.Builder bar = root.getGroups().initBar();
@@ -446,9 +454,9 @@ public class EncodingTest {
             bar.setGrault(new Text.Reader("barbaz"));
             bar.setGarply(234567890123456L);
 
-            Assertions.assertEquals(23456789, bar.getCorge());
-            Assertions.assertEquals("barbaz", bar.getGrault().toString());
-            Assertions.assertEquals(234567890123456L, bar.getGarply());
+            assertEquals(23456789, bar.getCorge());
+            assertEquals("barbaz", bar.getGrault().toString());
+            assertEquals(234567890123456L, bar.getGarply());
         }
         {
             org.capnproto.test.Test.TestGroups.Groups.Baz.Builder baz = root.getGroups().initBaz();
@@ -456,13 +464,13 @@ public class EncodingTest {
             baz.setGrault(new Text.Reader("bazqux"));
             baz.setGarply(new Text.Reader("quxquux"));
 
-            Assertions.assertEquals(34567890, baz.getCorge());
-            Assertions.assertEquals("bazqux", baz.getGrault().toString());
-            Assertions.assertEquals("quxquux", baz.getGarply().toString());
+            assertEquals(34567890, baz.getCorge());
+            assertEquals("bazqux", baz.getGrault().toString());
+            assertEquals("quxquux", baz.getGarply().toString());
         }
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testNestedLists() {
         MessageBuilder builder = new MessageBuilder();
         org.capnproto.test.Test.TestLists.Builder root = builder.initRoot(org.capnproto.test.Test.TestLists.factory);
@@ -479,118 +487,118 @@ public class EncodingTest {
         {
             org.capnproto.test.Test.TestLists.Reader reader = root.asReader();
             ListList.Reader<PrimitiveList.Int.Reader> intListList = reader.getInt32ListList();
-            Assertions.assertEquals(2, intListList.size());
+            assertEquals(2, intListList.size());
             PrimitiveList.Int.Reader intList0 = intListList.get(0);
-            Assertions.assertEquals(4, intList0.size());
-            Assertions.assertEquals(1, intList0.get(0));
-            Assertions.assertEquals(2, intList0.get(1));
-            Assertions.assertEquals(3, intList0.get(2));
-            Assertions.assertEquals(4, intList0.get(3));
+            assertEquals(4, intList0.size());
+            assertEquals(1, intList0.get(0));
+            assertEquals(2, intList0.get(1));
+            assertEquals(3, intList0.get(2));
+            assertEquals(4, intList0.get(3));
             PrimitiveList.Int.Reader intList1 = intListList.get(1);
-            Assertions.assertEquals(1, intList1.size());
-            Assertions.assertEquals(100, intList1.get(0));
+            assertEquals(1, intList1.size());
+            assertEquals(100, intList1.get(0));
         }
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testConstants() {
-        Assertions.assertEquals(Void.VOID, org.capnproto.test.Test.TestConstants.VOID_CONST);
-        Assertions.assertEquals(true, org.capnproto.test.Test.TestConstants.BOOL_CONST);
-        Assertions.assertEquals(-123, org.capnproto.test.Test.TestConstants.INT8_CONST);
-        Assertions.assertEquals(-12345, org.capnproto.test.Test.TestConstants.INT16_CONST);
-        Assertions.assertEquals(-12345678, org.capnproto.test.Test.TestConstants.INT32_CONST);
-        Assertions.assertEquals(-123456789012345L, org.capnproto.test.Test.TestConstants.INT64_CONST);
+        assertEquals(Void.VOID, org.capnproto.test.Test.TestConstants.VOID_CONST);
+        assertEquals(true, org.capnproto.test.Test.TestConstants.BOOL_CONST);
+        assertEquals(-123, org.capnproto.test.Test.TestConstants.INT8_CONST);
+        assertEquals(-12345, org.capnproto.test.Test.TestConstants.INT16_CONST);
+        assertEquals(-12345678, org.capnproto.test.Test.TestConstants.INT32_CONST);
+        assertEquals(-123456789012345L, org.capnproto.test.Test.TestConstants.INT64_CONST);
 
-        Assertions.assertEquals(-22, org.capnproto.test.Test.TestConstants.UINT8_CONST);
-        Assertions.assertEquals(-19858, org.capnproto.test.Test.TestConstants.UINT16_CONST);
-        Assertions.assertEquals(-838178284, org.capnproto.test.Test.TestConstants.UINT32_CONST);
-        Assertions.assertEquals(-6101065172474983726L, org.capnproto.test.Test.TestConstants.UINT64_CONST);
+        assertEquals(-22, org.capnproto.test.Test.TestConstants.UINT8_CONST);
+        assertEquals(-19858, org.capnproto.test.Test.TestConstants.UINT16_CONST);
+        assertEquals(-838178284, org.capnproto.test.Test.TestConstants.UINT32_CONST);
+        assertEquals(-6101065172474983726L, org.capnproto.test.Test.TestConstants.UINT64_CONST);
 
-        Assertions.assertEquals(1234.5f, org.capnproto.test.Test.TestConstants.FLOAT32_CONST, TestUtil.DELTA);
-        Assertions.assertEquals(-123e45, org.capnproto.test.Test.TestConstants.FLOAT64_CONST, TestUtil.DELTA);
+        assertEquals(1234.5f, org.capnproto.test.Test.TestConstants.FLOAT32_CONST, TestUtil.DELTA);
+        assertEquals(-123e45, org.capnproto.test.Test.TestConstants.FLOAT64_CONST, TestUtil.DELTA);
 
-        Assertions.assertEquals("foo", org.capnproto.test.Test.TestConstants.TEXT_CONST.toString());
-        Assertions.assertArrayEquals(TestUtil.data("bar"), org.capnproto.test.Test.TestConstants.DATA_CONST.toArray());
+        assertEquals("foo", org.capnproto.test.Test.TestConstants.TEXT_CONST.toString());
+        assertArrayEquals(TestUtil.data("bar"), org.capnproto.test.Test.TestConstants.DATA_CONST.toArray());
 
-        Assertions.assertEquals(org.capnproto.test.Test.TestEnum.CORGE, org.capnproto.test.Test.TestConstants.ENUM_CONST);
+        assertEquals(org.capnproto.test.Test.TestEnum.CORGE, org.capnproto.test.Test.TestConstants.ENUM_CONST);
         {
             org.capnproto.test.Test.TestAllTypes.Reader subReader = org.capnproto.test.Test.TestConstants.STRUCT_CONST;
-            Assertions.assertEquals(subReader.getBoolField(), true);
-            Assertions.assertEquals(subReader.getInt8Field(), -12);
-            Assertions.assertEquals(subReader.getInt16Field(), 3456);
-            Assertions.assertEquals(subReader.getInt32Field(), -78901234);
-            Assertions.assertEquals(subReader.getInt64Field(), 56789012345678L);
-            Assertions.assertEquals(subReader.getUInt8Field(), 90);
-            Assertions.assertEquals(subReader.getUInt16Field(), 1234);
-            Assertions.assertEquals(subReader.getUInt32Field(), 56789012);
-            Assertions.assertEquals(subReader.getUInt64Field(), 345678901234567890L);
-            Assertions.assertEquals(subReader.getFloat32Field(), -1.25e-10f, TestUtil.DELTA);
-            Assertions.assertEquals(subReader.getFloat64Field(), 345, TestUtil.DELTA);
-            Assertions.assertEquals(subReader.getTextField().toString(), "baz");
+            assertEquals(subReader.getBoolField(), true);
+            assertEquals(subReader.getInt8Field(), -12);
+            assertEquals(subReader.getInt16Field(), 3456);
+            assertEquals(subReader.getInt32Field(), -78901234);
+            assertEquals(subReader.getInt64Field(), 56789012345678L);
+            assertEquals(subReader.getUInt8Field(), 90);
+            assertEquals(subReader.getUInt16Field(), 1234);
+            assertEquals(subReader.getUInt32Field(), 56789012);
+            assertEquals(subReader.getUInt64Field(), 345678901234567890L);
+            assertEquals(subReader.getFloat32Field(), -1.25e-10f, TestUtil.DELTA);
+            assertEquals(subReader.getFloat64Field(), 345, TestUtil.DELTA);
+            assertEquals(subReader.getTextField().toString(), "baz");
         }
 
-        Assertions.assertEquals(6, org.capnproto.test.Test.TestConstants.VOID_LIST_CONST.size());
+        assertEquals(6, org.capnproto.test.Test.TestConstants.VOID_LIST_CONST.size());
 
         {
             PrimitiveList.Boolean.Reader listReader = org.capnproto.test.Test.TestConstants.BOOL_LIST_CONST;
-            Assertions.assertEquals(4, listReader.size());
-            Assertions.assertEquals(true, listReader.get(0));
-            Assertions.assertEquals(false, listReader.get(1));
-            Assertions.assertEquals(false, listReader.get(2));
-            Assertions.assertEquals(true, listReader.get(3));
+            assertEquals(4, listReader.size());
+            assertEquals(true, listReader.get(0));
+            assertEquals(false, listReader.get(1));
+            assertEquals(false, listReader.get(2));
+            assertEquals(true, listReader.get(3));
         }
 
         {
             TextList.Reader listReader = org.capnproto.test.Test.TestConstants.TEXT_LIST_CONST;
-            Assertions.assertEquals(3, listReader.size());
-            Assertions.assertEquals("plugh", listReader.get(0).toString());
-            Assertions.assertEquals("xyzzy", listReader.get(1).toString());
-            Assertions.assertEquals("thud", listReader.get(2).toString());
+            assertEquals(3, listReader.size());
+            assertEquals("plugh", listReader.get(0).toString());
+            assertEquals("xyzzy", listReader.get(1).toString());
+            assertEquals("thud", listReader.get(2).toString());
         }
 
         {
             StructList.Reader<org.capnproto.test.Test.TestAllTypes.Reader> listReader = org.capnproto.test.Test.TestConstants.STRUCT_LIST_CONST;
-            Assertions.assertEquals(3, listReader.size());
-            Assertions.assertEquals("structlist 1", listReader.get(0).getTextField().toString());
-            Assertions.assertEquals("structlist 2", listReader.get(1).getTextField().toString());
-            Assertions.assertEquals("structlist 3", listReader.get(2).getTextField().toString());
+            assertEquals(3, listReader.size());
+            assertEquals("structlist 1", listReader.get(0).getTextField().toString());
+            assertEquals("structlist 2", listReader.get(1).getTextField().toString());
+            assertEquals("structlist 3", listReader.get(2).getTextField().toString());
         }
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testGlobalConstants() {
-        Assertions.assertEquals(org.capnproto.test.Test.GLOBAL_INT, 12345);
+        assertEquals(org.capnproto.test.Test.GLOBAL_INT, 12345);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testEmptyStruct() {
         MessageBuilder builder = new MessageBuilder();
         org.capnproto.test.Test.TestAnyPointer.Builder root = builder.initRoot(org.capnproto.test.Test.TestAnyPointer.factory);
 
-        Assertions.assertFalse(root.hasAnyPointerField());
+        assertFalse(root.hasAnyPointerField());
 
         AnyPointer.Builder any = root.getAnyPointerField();
-        Assertions.assertTrue(any.isNull());
+        assertTrue(any.isNull());
         any.initAs(org.capnproto.test.Test.TestEmptyStruct.factory);
-        Assertions.assertFalse(any.isNull());
-        Assertions.assertTrue(root.hasAnyPointerField());
+        assertFalse(any.isNull());
+        assertTrue(root.hasAnyPointerField());
 
         {
             org.capnproto.test.Test.TestAnyPointer.Reader reader = root.asReader();
-            Assertions.assertTrue(reader.hasAnyPointerField());
-            Assertions.assertNotNull(reader.getAnyPointerField());
+            assertTrue(reader.hasAnyPointerField());
+            assertNotNull(reader.getAnyPointerField());
         }
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testTextBuilderIntUnderflow() {
         MessageBuilder builder = new MessageBuilder();
         org.capnproto.test.Test.TestAnyPointer.Builder root = builder.initRoot(org.capnproto.test.Test.TestAnyPointer.factory);
         root.getAnyPointerField().initAs(Data.factory, 0);
-        Assertions.assertThrows(DecodeException.class, () -> root.getAnyPointerField().getAs(Text.factory));
+        assertThrows(DecodeException.class, () -> root.getAnyPointerField().getAs(Text.factory));
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testInlineCompositeListIntOverflow() throws DecodeException {
 
         byte[] bytes = new byte[]{0,0,0,0, 0,0,1,0, 1,0,0,0, 0x17,0,0,0, 0,0,0,-128, 16,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0};
@@ -600,10 +608,10 @@ public class EncodingTest {
         MessageReader message = new MessageReader(new ByteBuffer[]{segment}, ReaderOptions.DEFAULT_READER_OPTIONS);
 
         org.capnproto.test.Test.TestAnyPointer.Reader root = message.getRoot(org.capnproto.test.Test.TestAnyPointer.factory);
-        Assertions.assertThrows(DecodeException.class, () -> root.getAnyPointerField().getAs(StructList.newFactory(org.capnproto.test.Test.TestAllTypes.factory)));
+        assertThrows(DecodeException.class, () -> root.getAnyPointerField().getAs(StructList.newFactory(org.capnproto.test.Test.TestAllTypes.factory)));
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testInlineCompositeListIntOverflow2() throws DecodeException {
 
         byte[] bytes = new byte[]{0,0,0,0, 0,0,1,0, 1,0,0,0, 0x17,0,0,0, 0,0,0,-128, 16,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0};
@@ -616,41 +624,41 @@ public class EncodingTest {
 
         MessageBuilder messageBuilder = new MessageBuilder();
         org.capnproto.test.Test.TestAnyPointer.Builder builderRoot = messageBuilder.initRoot(org.capnproto.test.Test.TestAnyPointer.factory);
-        Assertions.assertThrows(DecodeException.class, () -> builderRoot.getAnyPointerField().setAs(org.capnproto.test.Test.TestAnyPointer.factory, root));
+        assertThrows(DecodeException.class, () -> builderRoot.getAnyPointerField().setAs(org.capnproto.test.Test.TestAnyPointer.factory, root));
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testVoidListAmplification() throws DecodeException {
         MessageBuilder builder = new MessageBuilder();
         builder.initRoot(org.capnproto.test.Test.TestAnyPointer.factory).getAnyPointerField().initAs(PrimitiveList.Void.factory, 1 << 28);
 
         ByteBuffer[] segments = builder.getSegmentsForOutput();
-        Assertions.assertEquals(1, segments.length);
+        assertEquals(1, segments.length);
 
         MessageReader reader = new MessageReader(segments, ReaderOptions.DEFAULT_READER_OPTIONS);
         org.capnproto.test.Test.TestAnyPointer.Reader root = reader.getRoot(org.capnproto.test.Test.TestAnyPointer.factory);
-        Assertions.assertThrows(DecodeException.class, () -> root.getAnyPointerField().getAs(StructList.newFactory(org.capnproto.test.Test.TestAllTypes.factory)));
+        assertThrows(DecodeException.class, () -> root.getAnyPointerField().getAs(StructList.newFactory(org.capnproto.test.Test.TestAllTypes.factory)));
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testEmptyStructListAmplification() {
         MessageBuilder builder = new MessageBuilder();
         builder.initRoot(org.capnproto.test.Test.TestAnyPointer.factory).getAnyPointerField()
                 .initAs(StructList.newFactory(org.capnproto.test.Test.TestEmptyStruct.factory), (1 << 29) - 1);
 
         ByteBuffer[] segments = builder.getSegmentsForOutput();
-        Assertions.assertEquals(1, segments.length);
+        assertEquals(1, segments.length);
 
         MessageReader reader = new MessageReader(segments, ReaderOptions.DEFAULT_READER_OPTIONS);
         org.capnproto.test.Test.TestAnyPointer.Reader root = reader.getRoot(org.capnproto.test.Test.TestAnyPointer.factory);
-        Assertions.assertThrows(DecodeException.class, () -> root.getAnyPointerField().getAs(StructList.newFactory(org.capnproto.test.Test.TestAllTypes.factory)));
+        assertThrows(DecodeException.class, () -> root.getAnyPointerField().getAs(StructList.newFactory(org.capnproto.test.Test.TestAllTypes.factory)));
     }
 
     // Test that we throw an exception on out-of-bounds list pointers.
     // Before v0.1.11, we were vulnerable to a cpu amplification attack:
     // reading an out-of-bounds pointer to list a huge number of elements of size BIT,
     // when read as a struct list, would return without error.
-    @org.junit.jupiter.api.Test
+    @Test
     public void testListPointerOutOfBounds() throws DecodeException {
         byte[] bytes = new byte[]
                     {0,0,0,0, 0,0,1,0, // struct, one pointer
@@ -661,118 +669,118 @@ public class EncodingTest {
                                                   ReaderOptions.DEFAULT_READER_OPTIONS);
 
         org.capnproto.test.Test.TestAnyPointer.Reader root = message.getRoot(org.capnproto.test.Test.TestAnyPointer.factory);
-        Assertions.assertThrows(DecodeException.class, () -> root.getAnyPointerField().getAs(StructList.newFactory(org.capnproto.test.Test.TestAllTypes.factory)));
+        assertThrows(DecodeException.class, () -> root.getAnyPointerField().getAs(StructList.newFactory(org.capnproto.test.Test.TestAllTypes.factory)));
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testLongUint8List() {
       MessageBuilder message = new MessageBuilder();
       org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 28) + 1;
       PrimitiveList.Byte.Builder list = allTypes.initUInt8List(length);
-      Assertions.assertEquals(list.size(), length);
+      assertEquals(list.size(), length);
       list.set(length - 1, (byte)3);
-      Assertions.assertEquals(list.get(length - 1), 3);
-      Assertions.assertEquals(allTypes.asReader().getUInt8List().get(length - 1), 3);
+      assertEquals(list.get(length - 1), 3);
+      assertEquals(allTypes.asReader().getUInt8List().get(length - 1), 3);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testLongUint16List() {
       MessageBuilder message = new MessageBuilder();
       org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 27) + 1;
       PrimitiveList.Short.Builder list = allTypes.initUInt16List(length);
-      Assertions.assertEquals(list.size(), length);
+      assertEquals(list.size(), length);
       list.set(length - 1, (short)3);
-      Assertions.assertEquals(list.get(length - 1), 3);
-      Assertions.assertEquals(allTypes.asReader().getUInt16List().get(length - 1), 3);
+      assertEquals(list.get(length - 1), 3);
+      assertEquals(allTypes.asReader().getUInt16List().get(length - 1), 3);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testLongUint32List() {
       MessageBuilder message = new MessageBuilder();
       org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 26) + 1;
       PrimitiveList.Int.Builder list = allTypes.initUInt32List(length);
-      Assertions.assertEquals(list.size(), length);
+      assertEquals(list.size(), length);
       list.set(length - 1, 3);
-      Assertions.assertEquals(list.get(length - 1), 3);
-      Assertions.assertEquals(allTypes.asReader().getUInt32List().get(length - 1), 3);
+      assertEquals(list.get(length - 1), 3);
+      assertEquals(allTypes.asReader().getUInt32List().get(length - 1), 3);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testLongUint64List() {
       MessageBuilder message = new MessageBuilder();
       org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 25) + 1;
       PrimitiveList.Long.Builder list = allTypes.initUInt64List(length);
-      Assertions.assertEquals(list.size(), length);
+      assertEquals(list.size(), length);
       list.set(length - 1, 3);
-      Assertions.assertEquals(list.get(length - 1), 3);
-      Assertions.assertEquals(allTypes.asReader().getUInt64List().get(length - 1), 3);
+      assertEquals(list.get(length - 1), 3);
+      assertEquals(allTypes.asReader().getUInt64List().get(length - 1), 3);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testLongFloat32List() {
       MessageBuilder message = new MessageBuilder();
       org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 26) + 1;
       PrimitiveList.Float.Builder list = allTypes.initFloat32List(length);
-      Assertions.assertEquals(list.size(), length);
+      assertEquals(list.size(), length);
       list.set(length - 1, 3.14f);
-      Assertions.assertEquals(list.get(length - 1), 3.14f, 0.0f);
-      Assertions.assertEquals(allTypes.asReader().getFloat32List().get(length - 1), 3.14f, 0.0f);
+      assertEquals(list.get(length - 1), 3.14f, 0.0f);
+      assertEquals(allTypes.asReader().getFloat32List().get(length - 1), 3.14f, 0.0f);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testLongFloat64List() {
       MessageBuilder message = new MessageBuilder();
       org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 25) + 1;
       PrimitiveList.Double.Builder list = allTypes.initFloat64List(length);
-      Assertions.assertEquals(list.size(), length);
+      assertEquals(list.size(), length);
       list.set(length - 1, 3.14);
-      Assertions.assertEquals(list.get(length - 1), 3.14, 0.0);
-      Assertions.assertEquals(allTypes.asReader().getFloat64List().get(length - 1), 3.14, 0.0);
+      assertEquals(list.get(length - 1), 3.14, 0.0);
+      assertEquals(allTypes.asReader().getFloat64List().get(length - 1), 3.14, 0.0);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testLongStructList() {
       MessageBuilder message = new MessageBuilder();
       org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 21) + 1;
       StructList.Builder<org.capnproto.test.Test.TestAllTypes.Builder> list = allTypes.initStructList(length);
-      Assertions.assertEquals(list.size(), length);
+      assertEquals(list.size(), length);
       list.get(length - 1).setUInt8Field((byte)3);
-      Assertions.assertEquals(list.get(length - 1).getUInt8Field(), 3);
-      Assertions.assertEquals(allTypes.asReader().getStructList().get(length - 1).getUInt8Field(), 3);
+      assertEquals(list.get(length - 1).getUInt8Field(), 3);
+      assertEquals(allTypes.asReader().getStructList().get(length - 1).getUInt8Field(), 3);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testLongTextList() {
       MessageBuilder message = new MessageBuilder();
       org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 25) + 1;
       TextList.Builder list = allTypes.initTextList(length);
-      Assertions.assertEquals(list.size(), length);
+      assertEquals(list.size(), length);
       list.set(length - 1, new Text.Reader("foo"));
-      Assertions.assertEquals(list.get(length - 1).toString(), "foo");
-      Assertions.assertEquals(allTypes.asReader().getTextList().get(length - 1).toString(), "foo");
+      assertEquals(list.get(length - 1).toString(), "foo");
+      assertEquals(allTypes.asReader().getTextList().get(length - 1).toString(), "foo");
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testLongListList() {
       MessageBuilder message = new MessageBuilder();
       org.capnproto.test.Test.TestLists.Builder root = message.initRoot(org.capnproto.test.Test.TestLists.factory);
       int length = (1 << 25) + 1;
       ListList.Builder<StructList.Builder<org.capnproto.test.Test.TestAllTypes.Builder>> list = root.initStructListList(length);
-      Assertions.assertEquals(list.size(), length);
+      assertEquals(list.size(), length);
       list.init(length - 1, 3);
-      Assertions.assertEquals(list.get(length - 1).size(), 3);
-      Assertions.assertEquals(root.asReader().getStructListList().get(length - 1).size(), 3);
+      assertEquals(list.get(length - 1).size(), 3);
+      assertEquals(root.asReader().getStructListList().get(length - 1).size(), 3);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testStructSetters() {
       MessageBuilder builder = new MessageBuilder();
       org.capnproto.test.Test.TestAllTypes.Builder root = builder.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
@@ -799,7 +807,7 @@ public class EncodingTest {
       }
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testSerializedSize() {
       MessageBuilder builder = new MessageBuilder();
       org.capnproto.test.Test.TestAnyPointer.Builder root = builder.initRoot(org.capnproto.test.Test.TestAnyPointer.factory);
@@ -808,10 +816,10 @@ public class EncodingTest {
       // one word for segment table, one for the root pointer,
       // one for the body of the TestAnyPointer struct,
       // and one for the body of the Text.
-      Assertions.assertEquals(Serialize.computeSerializedSizeInWords(builder), 4);
+      assertEquals(Serialize.computeSerializedSizeInWords(builder), 4);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testImport() {
       MessageBuilder builder = new MessageBuilder();
       org.capnproto.testimport.TestImport.Foo.Builder root = builder.initRoot(org.capnproto.testimport.TestImport.Foo.factory);
@@ -821,7 +829,7 @@ public class EncodingTest {
       TestUtil.checkTestMessage(field.asReader());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testGenericMap() {
       MessageBuilder builder = new MessageBuilder();
       org.capnproto.test.Test.GenericMap.Factory<Text.Builder, Text.Reader, org.capnproto.test.Test.TestAllTypes.Builder, org.capnproto.test.Test.TestAllTypes.Reader> mapFactory
@@ -857,20 +865,20 @@ public class EncodingTest {
            root.asReader(mapFactory).getEntries(entryFactory);
 
          org.capnproto.test.Test.GenericMap.Entry.Reader<Text.Reader, org.capnproto.test.Test.TestAllTypes.Reader> entry0 = entries.get(0);
-         Assertions.assertEquals(entry0.getKey().toString(), "foo");
-         Assertions.assertEquals(entry0.getValue().getInt64Field(), 101);
+         assertEquals(entry0.getKey().toString(), "foo");
+         assertEquals(entry0.getValue().getInt64Field(), 101);
 
          org.capnproto.test.Test.GenericMap.Entry.Reader<Text.Reader, org.capnproto.test.Test.TestAllTypes.Reader> entry1 = entries.get(1);
-         Assertions.assertEquals(entry1.getKey().toString(), "bar");
-         Assertions.assertEquals(entry1.getValue().getInt64Field(), 202);
+         assertEquals(entry1.getKey().toString(), "bar");
+         assertEquals(entry1.getValue().getInt64Field(), 202);
 
          org.capnproto.test.Test.GenericMap.Entry.Reader<Text.Reader, org.capnproto.test.Test.TestAllTypes.Reader> entry2 = entries.get(2);
-         Assertions.assertEquals(entry2.getKey().toString(), "baz");
-         Assertions.assertEquals(entry2.getValue().getInt64Field(), 303);
+         assertEquals(entry2.getKey().toString(), "baz");
+         assertEquals(entry2.getValue().getInt64Field(), 303);
       }
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testSetWithCaveats() {
       MessageBuilder builder = new MessageBuilder();
       org.capnproto.test.Test.TestAllTypes.Builder root = builder.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
@@ -891,11 +899,11 @@ public class EncodingTest {
       }
 
       StructList.Reader<org.capnproto.test.Test.TestAllTypes.Reader> listReader = list.asReader(org.capnproto.test.Test.TestAllTypes.factory);
-      Assertions.assertEquals(listReader.get(0).getInt8Field(), 11);
+      assertEquals(listReader.get(0).getInt8Field(), 11);
       TestUtil.checkTestMessage(listReader.get(1));
   }
 
-  @org.junit.jupiter.api.Test
+  @Test
   public void testCopyAnyPointer() {
       MessageBuilder message1 = new MessageBuilder();
       org.capnproto.test.Test.TestAllTypes.Builder root1 = message1.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
@@ -908,7 +916,7 @@ public class EncodingTest {
       TestUtil.checkTestMessage(root2.getAs(org.capnproto.test.Test.TestAllTypes.factory));
   }
 
-  @org.junit.jupiter.api.Test
+  @Test
   public void testZeroPointerUnderflow() throws DecodeException {
       byte[] bytes = new byte[8 + 8 * 65535];
       bytes[4] = -1;
@@ -934,20 +942,20 @@ public class EncodingTest {
       message2RootBuilder.getAnyPointerField().clear();
 
       java.nio.ByteBuffer[] outputSegments = message2Builder.getSegmentsForOutput();
-      Assertions.assertEquals(1, outputSegments.length);
-      Assertions.assertEquals(0L, outputSegments[0].getLong(8)); // null because cleared
+      assertEquals(1, outputSegments.length);
+      assertEquals(0L, outputSegments[0].getLong(8)); // null because cleared
 
-      Assertions.assertEquals(16 + 8 * 65535, outputSegments[0].limit());
+      assertEquals(16 + 8 * 65535, outputSegments[0].limit());
       for (int ii = 0; ii < 65535; ++ii) {
           // All of the data should have been cleared.
-          Assertions.assertEquals(0L, outputSegments[0].getLong((2 + ii) * 8));
+          assertEquals(0L, outputSegments[0].getLong((2 + ii) * 8));
       }
     }
 
     // This test fails on https://github.com/capnproto/capnproto-java/pull/143,
     // illustrating why https://github.com/capnproto/capnproto-java/commit/28ab5ced
     // is needed.
-    @org.junit.jupiter.api.Test
+    @Test
     public void setDataPointer() {
         MessageBuilder message1 = new MessageBuilder();
         org.capnproto.test.Test.TestAllTypes.Builder allTypes1 = message1.initRoot(org.capnproto.test.Test.TestAllTypes.factory);

--- a/compiler/src/test/java/org/capnproto/test/EncodingTest.java
+++ b/compiler/src/test/java/org/capnproto/test/EncodingTest.java
@@ -76,7 +76,7 @@ public class EncodingTest {
         ByteBuffer[] segments = message.getSegmentsForOutput();
         for (ByteBuffer segment : segments) {
             for (int j = 0; j < segment.limit(); j++) {
-                assertEquals(segment.get(j), 0);
+                assertEquals(0, segment.get(j));
             }
         }
     }
@@ -92,8 +92,8 @@ public class EncodingTest {
         org.capnproto.test.Test.TestAllTypes.Reader root = message.getRoot(org.capnproto.test.Test.TestAllTypes.factory);
 
         assertTrue(root.getBoolField());
-        assertEquals(root.getInt8Field(), 7);
-        assertEquals(root.getInt16Field(), 32767);
+        assertEquals(7, root.getInt8Field());
+        assertEquals(32767, root.getInt16Field());
     }
 
     @Test
@@ -112,11 +112,11 @@ public class EncodingTest {
 
       {
         org.capnproto.test.Test.TestNewVersion.Reader newVersion = root.getAnyPointerField().asReader().getAs(org.capnproto.test.Test.TestNewVersion.factory);
-        assertEquals(newVersion.getOld1(), 123);
-        assertEquals(newVersion.getOld2().toString(), "foo");
-        assertEquals(newVersion.getNew2().toString(),  "baz");
-        assertEquals(newVersion.hasNew2(), false);
-        assertEquals(newVersion.hasNew3(), false);
+        assertEquals(123, newVersion.getOld1());
+        assertEquals("foo", newVersion.getOld2().toString());
+        assertEquals("baz", newVersion.getNew2().toString());
+        assertEquals(false, newVersion.hasNew2());
+        assertEquals(false, newVersion.hasNew3());
       }
     }
 
@@ -142,11 +142,11 @@ public class EncodingTest {
 
       {
         org.capnproto.test.Test.TestOldVersion.Reader oldVersion = root.getAnyPointerField().asReader().getAs(org.capnproto.test.Test.TestOldVersion.factory);
-        assertEquals(oldVersion.getOld1(), 123);
-        assertEquals(oldVersion.getOld2().toString(), "foo");
+        assertEquals(123, oldVersion.getOld1());
+        assertEquals("foo", oldVersion.getOld2().toString());
 
         TextList.Reader names = oldVersion.getOld4();
-        assertEquals(names.size(), 2);
+        assertEquals(2, names.size());
         assertEquals("alice", names.get(0).toString());
         assertEquals("bob", names.get(1).toString());
       }
@@ -167,13 +167,13 @@ public class EncodingTest {
         }
         {
             org.capnproto.test.Test.TestNewVersion.Builder newVersion = root.getAnyPointerField().getAs(org.capnproto.test.Test.TestNewVersion.factory);
-            assertEquals(newVersion.getOld1(), 123);
-            assertEquals(newVersion.getOld2().toString(), "foo");
-            assertEquals(newVersion.getNew1(), 987);
-            assertEquals(newVersion.getNew2().toString(), "baz");
+            assertEquals(123, newVersion.getOld1());
+            assertEquals("foo", newVersion.getOld2().toString());
+            assertEquals(987, newVersion.getNew1());
+            assertEquals("baz", newVersion.getNew2().toString());
             org.capnproto.test.Test.TestNewVersion.Builder sub = newVersion.getOld3();
-            assertEquals(sub.getOld1(), 456);
-            assertEquals(sub.getOld2().toString(), "bar");
+            assertEquals(456, sub.getOld1());
+            assertEquals("bar", sub.getOld2().toString());
 
             newVersion.setOld1(234);
             newVersion.setOld2("qux");
@@ -182,8 +182,8 @@ public class EncodingTest {
         }
         {
             org.capnproto.test.Test.TestOldVersion.Builder oldVersion = root.getAnyPointerField().getAs(org.capnproto.test.Test.TestOldVersion.factory);
-            assertEquals(oldVersion.getOld1(), 234);
-            assertEquals(oldVersion.getOld2().toString(), "qux");
+            assertEquals(234, oldVersion.getOld1());
+            assertEquals("qux", oldVersion.getOld2().toString());
         }
     }
 
@@ -201,16 +201,16 @@ public class EncodingTest {
         }
         {
             StructList.Reader<org.capnproto.test.Test.TestOldVersion.Reader> olds = any.asReader().getAs(org.capnproto.test.Test.TestOldVersion.listFactory);
-            assertEquals(olds.get(0).getOld1(), 123);
-            assertEquals(olds.get(1).getOld1(), 456);
-            assertEquals(olds.get(2).getOld1(), 789);
+            assertEquals(123, olds.get(0).getOld1());
+            assertEquals(456, olds.get(1).getOld1());
+            assertEquals(789, olds.get(2).getOld1());
         }
         {
             StructList.Builder<org.capnproto.test.Test.TestOldVersion.Builder> olds = any.getAs(org.capnproto.test.Test.TestOldVersion.listFactory);
-            assertEquals(olds.size(), 3);
-            assertEquals(olds.get(0).getOld1(), 123);
-            assertEquals(olds.get(1).getOld1(), 456);
-            assertEquals(olds.get(2).getOld1(), 789);
+            assertEquals(3, olds.size());
+            assertEquals(123, olds.get(0).getOld1());
+            assertEquals(456, olds.get(1).getOld1());
+            assertEquals(789, olds.get(2).getOld1());
 
             olds.get(0).setOld2("zero");
             olds.get(1).setOld2("one");
@@ -218,15 +218,15 @@ public class EncodingTest {
         }
         {
             StructList.Builder<org.capnproto.test.Test.TestNewVersion.Builder> news = any.getAs(org.capnproto.test.Test.TestNewVersion.listFactory);
-            assertEquals(news.size(), 3);
-            assertEquals(news.get(0).getOld1(), 123);
-            assertEquals(news.get(0).getOld2().toString(), "zero");
+            assertEquals(3, news.size());
+            assertEquals(123, news.get(0).getOld1());
+            assertEquals("zero", news.get(0).getOld2().toString());
 
-            assertEquals(news.get(1).getOld1(), 456);
-            assertEquals(news.get(1).getOld2().toString(), "one");
+            assertEquals(456, news.get(1).getOld1());
+            assertEquals("one", news.get(1).getOld2().toString());
 
-            assertEquals(news.get(2).getOld1(), 789);
-            assertEquals(news.get(2).getOld2().toString(), "two");
+            assertEquals(789, news.get(2).getOld1());
+            assertEquals("two", news.get(2).getOld2().toString());
         }
     }
 
@@ -246,9 +246,9 @@ public class EncodingTest {
 
       StructList.Reader<org.capnproto.test.Test.TestOldVersion.Reader> oldVersion = messageReader.getRoot(StructList.newFactory(org.capnproto.test.Test.TestOldVersion.factory));
 
-      assertEquals(oldVersion.size(), 1);
-      assertEquals(oldVersion.get(0).getOld1(), 91);
-      assertEquals(oldVersion.get(0).getOld2().toString(), "hello!!");
+      assertEquals(1, oldVersion.size());
+      assertEquals(91, oldVersion.get(0).getOld1());
+      assertEquals("hello!!", oldVersion.get(0).getOld2().toString());
 
       // Make the first segment exactly large enough to fit the original message.
       // This leaves no room for a far pointer landing pad in the first segment.
@@ -256,20 +256,20 @@ public class EncodingTest {
       message.setRoot(StructList.newFactory(org.capnproto.test.Test.TestOldVersion.factory), oldVersion);
 
       ByteBuffer[] segments = message.getSegmentsForOutput();
-      assertEquals(segments.length, 1);
-      assertEquals(segments[0].limit(), 6 * 8);
+      assertEquals(1, segments.length);
+      assertEquals(6 * 8, segments[0].limit());
 
       StructList.Builder<org.capnproto.test.Test.TestNewVersion.Builder> newVersion =
         message.getRoot(new StructList.Factory<org.capnproto.test.Test.TestNewVersion.Builder, org.capnproto.test.Test.TestNewVersion.Reader>(org.capnproto.test.Test.TestNewVersion.factory));
-      assertEquals(newVersion.size(), 1);
-      assertEquals(newVersion.get(0).getOld1(), 91);
-      assertEquals(newVersion.get(0).getOld2().toString(), "hello!!");
+      assertEquals(1, newVersion.size());
+      assertEquals(91, newVersion.get(0).getOld1());
+      assertEquals("hello!!", newVersion.get(0).getOld2().toString());
 
       ByteBuffer[] segments1 = message.getSegmentsForOutput();
-      assertEquals(segments[0].limit(), 6 * 8);
+      assertEquals(6 * 8, segments[0].limit());
       for (int ii = 8; ii < (5 * 8) - 1; ++ii) {
         // Check the the old list, including the tag, was zeroed.
-        assertEquals(segments[0].get(ii), 0);
+        assertEquals(0, segments[0].get(ii));
       }
     }
 
@@ -279,62 +279,62 @@ public class EncodingTest {
       org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
 
       allTypes.initVoidList(10);
-      assertEquals(allTypes.getVoidList().asReader().size(), 10);
+      assertEquals(10, allTypes.getVoidList().asReader().size());
 
       PrimitiveList.Boolean.Builder boolList = allTypes.initBoolList(7);
       boolList.set(3, true);
       PrimitiveList.Boolean.Reader boolListReader = boolList.asReader();
-      assertEquals(boolListReader.size(), 7);
-      assertEquals(boolListReader.get(0), false);
-      assertEquals(boolListReader.get(1), false);
-      assertEquals(boolListReader.get(2), false);
-      assertEquals(boolListReader.get(3), true);
-      assertEquals(boolListReader.get(4), false);
+      assertEquals(7, boolListReader.size());
+      assertEquals(false, boolListReader.get(0));
+      assertEquals(false, boolListReader.get(1));
+      assertEquals(false, boolListReader.get(2));
+      assertEquals(true, boolListReader.get(3));
+      assertEquals(false, boolListReader.get(4));
 
       PrimitiveList.Byte.Builder int8List = allTypes.initInt8List(9);
       int8List.set(4, (byte)100);
       int8List.set(8, (byte)11);
       PrimitiveList.Byte.Reader int8ListReader = int8List.asReader();
-      assertEquals(int8ListReader.size(), 9);
-      assertEquals(int8ListReader.get(0), 0);
-      assertEquals(int8ListReader.get(4), 100);
-      assertEquals(int8ListReader.get(8), 11);
+      assertEquals(9, int8ListReader.size());
+      assertEquals(0, int8ListReader.get(0));
+      assertEquals(100, int8ListReader.get(4));
+      assertEquals(11, int8ListReader.get(8));
 
       PrimitiveList.Short.Builder int16List = allTypes.initInt16List(2);
       int16List.set(0, (short)1);
       PrimitiveList.Short.Reader int16ListReader = int16List.asReader();
-      assertEquals(int16ListReader.size(), 2);
-      assertEquals(int16ListReader.get(0), 1);
-      assertEquals(int16ListReader.get(1), 0);
+      assertEquals(2, int16ListReader.size());
+      assertEquals(1, int16ListReader.get(0));
+      assertEquals(0, int16ListReader.get(1));
 
       // TODO other primitive lists
 
       TextList.Builder textList = allTypes.initTextList(1);
       textList.set(0, new Text.Reader("abcdefg"));
       TextList.Reader textListReader = textList.asReader();
-      assertEquals(textListReader.size(), 1);
-      assertEquals(textListReader.get(0).toString(), "abcdefg");
+      assertEquals(1, textListReader.size());
+      assertEquals("abcdefg", textListReader.get(0).toString());
 
       DataList.Builder dataList = allTypes.initDataList(1);
       dataList.set(0, new Data.Reader(new byte[]{1,2,3,4}));
       DataList.Reader dataListReader = dataList.asReader();
-      assertEquals(dataListReader.size(), 1);
+      assertEquals(1, dataListReader.size());
       assertTrue(java.util.Arrays.equals(dataListReader.get(0).toArray(), new byte[]{1,2,3,4}));
 
       StructList.Builder<org.capnproto.test.Test.TestAllTypes.Builder> structList = allTypes.initStructList(2);
       structList.get(0).setInt8Field((byte)5);
       structList.get(1).setInt8Field((byte)9);
       StructList.Reader<org.capnproto.test.Test.TestAllTypes.Reader> structListReader = structList.asReader(org.capnproto.test.Test.TestAllTypes.factory);
-      assertEquals(structListReader.size(), 2);
-      assertEquals(structListReader.get(0).getInt8Field(), 5);
-      assertEquals(structListReader.get(1).getInt8Field(), 9);
+      assertEquals(2, structListReader.size());
+      assertEquals(5, structListReader.get(0).getInt8Field());
+      assertEquals(9, structListReader.get(1).getInt8Field());
 
       EnumList.Builder<org.capnproto.test.Test.TestEnum> enumList = allTypes.initEnumList(3);
       enumList.set(0, org.capnproto.test.Test.TestEnum.FOO);
       enumList.set(1, org.capnproto.test.Test.TestEnum.BAR);
       enumList.set(2, org.capnproto.test.Test.TestEnum.BAZ);
       EnumList.Reader<org.capnproto.test.Test.TestEnum> enumListReader = enumList.asReader();
-      assertEquals(enumListReader.size(), 3);
+      assertEquals(3, enumListReader.size());
       assertEquals(enumListReader.get(0), org.capnproto.test.Test.TestEnum.FOO);
       assertEquals(enumListReader.get(1), org.capnproto.test.Test.TestEnum.BAR);
       assertEquals(enumListReader.get(2), org.capnproto.test.Test.TestEnum.BAZ);
@@ -356,16 +356,16 @@ public class EncodingTest {
 
       ListList.Reader<StructList.Reader<org.capnproto.test.Test.TestAllTypes.Reader>> structListListReader =
         structListList.asReader(StructList.newFactory(org.capnproto.test.Test.TestAllTypes.factory));
-      assertEquals(structListListReader.size(), 3);
+      assertEquals(3, structListListReader.size());
       StructList.Reader<org.capnproto.test.Test.TestAllTypes.Reader> structList0Reader = structListListReader.get(0);
-      assertEquals(structList0Reader.size(), 1);
-      assertEquals(structList0Reader.get(0).getInt16Field(), 1);
-      assertEquals(structListListReader.get(1).size(), 0);
+      assertEquals(1, structList0Reader.size());
+      assertEquals(1, structList0Reader.get(0).getInt16Field());
+      assertEquals(0, structListListReader.get(1).size());
       StructList.Reader<org.capnproto.test.Test.TestAllTypes.Reader> structList2Reader = structListListReader.get(2);
-      assertEquals(structList2Reader.size(), 3);
-      assertEquals(structList2Reader.get(0).getInt16Field(), 22);
-      assertEquals(structList2Reader.get(1).getInt16Field(), 333);
-      assertEquals(structList2Reader.get(2).getInt16Field(), 4444);
+      assertEquals(3, structList2Reader.size());
+      assertEquals(22, structList2Reader.get(0).getInt16Field());
+      assertEquals(333, structList2Reader.get(1).getInt16Field());
+      assertEquals(4444, structList2Reader.get(2).getInt16Field());
     }
 
     @Test
@@ -390,7 +390,7 @@ public class EncodingTest {
             root.asReader(org.capnproto.test.Test.TestGenerics.newFactory(org.capnproto.test.Test.TestAllTypes.factory, Text.factory));
         TestUtil.checkTestMessage(rootReader.getFoo());
         org.capnproto.test.Test.TestGenerics.Builder<Text.Builder, PrimitiveList.Byte.Builder> dubReader = root.getDub();
-        assertEquals(dubReader.getFoo().toString(), "Hello");
+        assertEquals("Hello", dubReader.getFoo().toString());
         PrimitiveList.Byte.Builder barReader = dubReader.getBar();
         assertEquals(1, barReader.size());
         assertEquals(11, barReader.get(0));
@@ -523,18 +523,18 @@ public class EncodingTest {
         assertEquals(org.capnproto.test.Test.TestEnum.CORGE, org.capnproto.test.Test.TestConstants.ENUM_CONST);
         {
             org.capnproto.test.Test.TestAllTypes.Reader subReader = org.capnproto.test.Test.TestConstants.STRUCT_CONST;
-            assertEquals(subReader.getBoolField(), true);
-            assertEquals(subReader.getInt8Field(), -12);
-            assertEquals(subReader.getInt16Field(), 3456);
-            assertEquals(subReader.getInt32Field(), -78901234);
-            assertEquals(subReader.getInt64Field(), 56789012345678L);
-            assertEquals(subReader.getUInt8Field(), 90);
-            assertEquals(subReader.getUInt16Field(), 1234);
-            assertEquals(subReader.getUInt32Field(), 56789012);
-            assertEquals(subReader.getUInt64Field(), 345678901234567890L);
-            assertEquals(subReader.getFloat32Field(), -1.25e-10f, TestUtil.DELTA);
-            assertEquals(subReader.getFloat64Field(), 345, TestUtil.DELTA);
-            assertEquals(subReader.getTextField().toString(), "baz");
+            assertEquals(true, subReader.getBoolField());
+            assertEquals(-12, subReader.getInt8Field());
+            assertEquals(3456, subReader.getInt16Field());
+            assertEquals(-78901234, subReader.getInt32Field());
+            assertEquals(56789012345678L, subReader.getInt64Field());
+            assertEquals(90, subReader.getUInt8Field());
+            assertEquals(1234, subReader.getUInt16Field());
+            assertEquals(56789012, subReader.getUInt32Field());
+            assertEquals(345678901234567890L, subReader.getUInt64Field());
+            assertEquals(-1.25e-10f, subReader.getFloat32Field(), TestUtil.DELTA);
+            assertEquals(345, subReader.getFloat64Field(), TestUtil.DELTA);
+            assertEquals("baz", subReader.getTextField().toString());
         }
 
         assertEquals(6, org.capnproto.test.Test.TestConstants.VOID_LIST_CONST.size());
@@ -567,7 +567,7 @@ public class EncodingTest {
 
     @Test
     public void testGlobalConstants() {
-        assertEquals(org.capnproto.test.Test.GLOBAL_INT, 12345);
+        assertEquals(12345, org.capnproto.test.Test.GLOBAL_INT);
     }
 
     @Test
@@ -678,10 +678,10 @@ public class EncodingTest {
       org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 28) + 1;
       PrimitiveList.Byte.Builder list = allTypes.initUInt8List(length);
-      assertEquals(list.size(), length);
+      assertEquals(length, list.size());
       list.set(length - 1, (byte)3);
-      assertEquals(list.get(length - 1), 3);
-      assertEquals(allTypes.asReader().getUInt8List().get(length - 1), 3);
+      assertEquals(3, list.get(length - 1));
+      assertEquals(3, allTypes.asReader().getUInt8List().get(length - 1));
     }
 
     @Test
@@ -690,10 +690,10 @@ public class EncodingTest {
       org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 27) + 1;
       PrimitiveList.Short.Builder list = allTypes.initUInt16List(length);
-      assertEquals(list.size(), length);
+      assertEquals(length, list.size());
       list.set(length - 1, (short)3);
-      assertEquals(list.get(length - 1), 3);
-      assertEquals(allTypes.asReader().getUInt16List().get(length - 1), 3);
+      assertEquals(3, list.get(length - 1));
+      assertEquals(3, allTypes.asReader().getUInt16List().get(length - 1));
     }
 
     @Test
@@ -702,10 +702,10 @@ public class EncodingTest {
       org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 26) + 1;
       PrimitiveList.Int.Builder list = allTypes.initUInt32List(length);
-      assertEquals(list.size(), length);
+      assertEquals(length, list.size());
       list.set(length - 1, 3);
-      assertEquals(list.get(length - 1), 3);
-      assertEquals(allTypes.asReader().getUInt32List().get(length - 1), 3);
+      assertEquals(3, list.get(length - 1));
+      assertEquals(3, allTypes.asReader().getUInt32List().get(length - 1));
     }
 
     @Test
@@ -714,10 +714,10 @@ public class EncodingTest {
       org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 25) + 1;
       PrimitiveList.Long.Builder list = allTypes.initUInt64List(length);
-      assertEquals(list.size(), length);
+      assertEquals(length, list.size());
       list.set(length - 1, 3);
-      assertEquals(list.get(length - 1), 3);
-      assertEquals(allTypes.asReader().getUInt64List().get(length - 1), 3);
+      assertEquals(3, list.get(length - 1));
+      assertEquals(3, allTypes.asReader().getUInt64List().get(length - 1));
     }
 
     @Test
@@ -726,10 +726,10 @@ public class EncodingTest {
       org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 26) + 1;
       PrimitiveList.Float.Builder list = allTypes.initFloat32List(length);
-      assertEquals(list.size(), length);
+      assertEquals(length, list.size());
       list.set(length - 1, 3.14f);
-      assertEquals(list.get(length - 1), 3.14f, 0.0f);
-      assertEquals(allTypes.asReader().getFloat32List().get(length - 1), 3.14f, 0.0f);
+      assertEquals(3.14f, list.get(length - 1), 0.0f);
+      assertEquals(3.14f, allTypes.asReader().getFloat32List().get(length - 1), 0.0f);
     }
 
     @Test
@@ -738,10 +738,10 @@ public class EncodingTest {
       org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 25) + 1;
       PrimitiveList.Double.Builder list = allTypes.initFloat64List(length);
-      assertEquals(list.size(), length);
+      assertEquals(length, list.size());
       list.set(length - 1, 3.14);
-      assertEquals(list.get(length - 1), 3.14, 0.0);
-      assertEquals(allTypes.asReader().getFloat64List().get(length - 1), 3.14, 0.0);
+      assertEquals(3.14, list.get(length - 1), 0.0);
+      assertEquals(3.14, allTypes.asReader().getFloat64List().get(length - 1), 0.0);
     }
 
     @Test
@@ -750,10 +750,10 @@ public class EncodingTest {
       org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 21) + 1;
       StructList.Builder<org.capnproto.test.Test.TestAllTypes.Builder> list = allTypes.initStructList(length);
-      assertEquals(list.size(), length);
+      assertEquals(length, list.size());
       list.get(length - 1).setUInt8Field((byte)3);
-      assertEquals(list.get(length - 1).getUInt8Field(), 3);
-      assertEquals(allTypes.asReader().getStructList().get(length - 1).getUInt8Field(), 3);
+      assertEquals(3, list.get(length - 1).getUInt8Field());
+      assertEquals(3, allTypes.asReader().getStructList().get(length - 1).getUInt8Field());
     }
 
     @Test
@@ -762,10 +762,10 @@ public class EncodingTest {
       org.capnproto.test.Test.TestAllTypes.Builder allTypes = message.initRoot(org.capnproto.test.Test.TestAllTypes.factory);
       int length = (1 << 25) + 1;
       TextList.Builder list = allTypes.initTextList(length);
-      assertEquals(list.size(), length);
+      assertEquals(length, list.size());
       list.set(length - 1, new Text.Reader("foo"));
-      assertEquals(list.get(length - 1).toString(), "foo");
-      assertEquals(allTypes.asReader().getTextList().get(length - 1).toString(), "foo");
+      assertEquals("foo", list.get(length - 1).toString());
+      assertEquals("foo", allTypes.asReader().getTextList().get(length - 1).toString());
     }
 
     @Test
@@ -774,10 +774,10 @@ public class EncodingTest {
       org.capnproto.test.Test.TestLists.Builder root = message.initRoot(org.capnproto.test.Test.TestLists.factory);
       int length = (1 << 25) + 1;
       ListList.Builder<StructList.Builder<org.capnproto.test.Test.TestAllTypes.Builder>> list = root.initStructListList(length);
-      assertEquals(list.size(), length);
+      assertEquals(length, list.size());
       list.init(length - 1, 3);
-      assertEquals(list.get(length - 1).size(), 3);
-      assertEquals(root.asReader().getStructListList().get(length - 1).size(), 3);
+      assertEquals(3, list.get(length - 1).size());
+      assertEquals(3, root.asReader().getStructListList().get(length - 1).size());
     }
 
     @Test
@@ -816,7 +816,7 @@ public class EncodingTest {
       // one word for segment table, one for the root pointer,
       // one for the body of the TestAnyPointer struct,
       // and one for the body of the Text.
-      assertEquals(Serialize.computeSerializedSizeInWords(builder), 4);
+      assertEquals(4, Serialize.computeSerializedSizeInWords(builder));
     }
 
     @Test
@@ -865,16 +865,16 @@ public class EncodingTest {
            root.asReader(mapFactory).getEntries(entryFactory);
 
          org.capnproto.test.Test.GenericMap.Entry.Reader<Text.Reader, org.capnproto.test.Test.TestAllTypes.Reader> entry0 = entries.get(0);
-         assertEquals(entry0.getKey().toString(), "foo");
-         assertEquals(entry0.getValue().getInt64Field(), 101);
+         assertEquals("foo", entry0.getKey().toString());
+         assertEquals(101, entry0.getValue().getInt64Field());
 
          org.capnproto.test.Test.GenericMap.Entry.Reader<Text.Reader, org.capnproto.test.Test.TestAllTypes.Reader> entry1 = entries.get(1);
-         assertEquals(entry1.getKey().toString(), "bar");
-         assertEquals(entry1.getValue().getInt64Field(), 202);
+         assertEquals("bar", entry1.getKey().toString());
+         assertEquals(202, entry1.getValue().getInt64Field());
 
          org.capnproto.test.Test.GenericMap.Entry.Reader<Text.Reader, org.capnproto.test.Test.TestAllTypes.Reader> entry2 = entries.get(2);
-         assertEquals(entry2.getKey().toString(), "baz");
-         assertEquals(entry2.getValue().getInt64Field(), 303);
+         assertEquals("baz", entry2.getKey().toString());
+         assertEquals(303, entry2.getValue().getInt64Field());
       }
     }
 
@@ -899,7 +899,7 @@ public class EncodingTest {
       }
 
       StructList.Reader<org.capnproto.test.Test.TestAllTypes.Reader> listReader = list.asReader(org.capnproto.test.Test.TestAllTypes.factory);
-      assertEquals(listReader.get(0).getInt8Field(), 11);
+      assertEquals(11, listReader.get(0).getInt8Field());
       TestUtil.checkTestMessage(listReader.get(1));
   }
 

--- a/compiler/src/test/java/org/capnproto/test/TestUtil.java
+++ b/compiler/src/test/java/org/capnproto/test/TestUtil.java
@@ -5,12 +5,18 @@ import org.junit.jupiter.api.Assertions;
 
 import java.io.UnsupportedEncodingException;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 public class TestUtil {
     public static byte[] data(String string) {
         try {
             return string.getBytes("ISO_8859-1");
         } catch (UnsupportedEncodingException e) {
-            Assertions.fail("Could not decode");
+            fail("Could not decode");
             return null;
         }
     }
@@ -95,223 +101,223 @@ public class TestUtil {
 
     public static void checkTestMessage(org.capnproto.test.Test.TestAllTypes.Builder builder) {
         builder.getVoidField();
-        Assertions.assertEquals(builder.getBoolField(), true);
-        Assertions.assertEquals(builder.getInt8Field(), -123);
-        Assertions.assertEquals(builder.getInt16Field(), -12345);
-        Assertions.assertEquals(builder.getInt32Field(), -12345678);
-        Assertions.assertEquals(builder.getInt64Field(), -123456789012345L);
-        Assertions.assertEquals(builder.getUInt8Field(), (byte) 0xea);
-        Assertions.assertEquals(builder.getUInt16Field(), 0x4567);
-        Assertions.assertEquals(builder.getUInt32Field(), 0x34567890);
-        Assertions.assertEquals(builder.getUInt64Field(), 0x1234567890123456L);
-        Assertions.assertEquals(builder.getFloat32Field(), 1234.5f, DELTA);
-        Assertions.assertEquals(builder.getFloat64Field(), -123e45, DELTA);
-        Assertions.assertEquals(builder.getTextField().toString(), "foo");
+        assertEquals(builder.getBoolField(), true);
+        assertEquals(builder.getInt8Field(), -123);
+        assertEquals(builder.getInt16Field(), -12345);
+        assertEquals(builder.getInt32Field(), -12345678);
+        assertEquals(builder.getInt64Field(), -123456789012345L);
+        assertEquals(builder.getUInt8Field(), (byte) 0xea);
+        assertEquals(builder.getUInt16Field(), 0x4567);
+        assertEquals(builder.getUInt32Field(), 0x34567890);
+        assertEquals(builder.getUInt64Field(), 0x1234567890123456L);
+        assertEquals(builder.getFloat32Field(), 1234.5f, DELTA);
+        assertEquals(builder.getFloat64Field(), -123e45, DELTA);
+        assertEquals(builder.getTextField().toString(), "foo");
 
         {
             org.capnproto.test.Test.TestAllTypes.Builder subBuilder = builder.getStructField();
             subBuilder.getVoidField();
-            Assertions.assertEquals(subBuilder.getBoolField(), true);
-            Assertions.assertEquals(subBuilder.getInt8Field(), -12);
-            Assertions.assertEquals(subBuilder.getInt16Field(), 3456);
-            Assertions.assertEquals(subBuilder.getInt32Field(), -78901234);
-            Assertions.assertEquals(subBuilder.getInt64Field(), 56789012345678L);
-            Assertions.assertEquals(subBuilder.getUInt8Field(), 90);
-            Assertions.assertEquals(subBuilder.getUInt16Field(), 1234);
-            Assertions.assertEquals(subBuilder.getUInt32Field(), 56789012);
-            Assertions.assertEquals(subBuilder.getUInt64Field(), 345678901234567890L);
-            Assertions.assertEquals(subBuilder.getFloat32Field(), -1.25e-10f, DELTA);
-            Assertions.assertEquals(subBuilder.getFloat64Field(), 345, DELTA);
+            assertEquals(subBuilder.getBoolField(), true);
+            assertEquals(subBuilder.getInt8Field(), -12);
+            assertEquals(subBuilder.getInt16Field(), 3456);
+            assertEquals(subBuilder.getInt32Field(), -78901234);
+            assertEquals(subBuilder.getInt64Field(), 56789012345678L);
+            assertEquals(subBuilder.getUInt8Field(), 90);
+            assertEquals(subBuilder.getUInt16Field(), 1234);
+            assertEquals(subBuilder.getUInt32Field(), 56789012);
+            assertEquals(subBuilder.getUInt64Field(), 345678901234567890L);
+            assertEquals(subBuilder.getFloat32Field(), -1.25e-10f, DELTA);
+            assertEquals(subBuilder.getFloat64Field(), 345, DELTA);
 
             {
                 org.capnproto.test.Test.TestAllTypes.Builder subSubBuilder = subBuilder.getStructField();
-                Assertions.assertEquals(subSubBuilder.getTextField().toString(), "nested");
+                assertEquals(subSubBuilder.getTextField().toString(), "nested");
             }
 
-            Assertions.assertEquals(subBuilder.getEnumField(), org.capnproto.test.Test.TestEnum.BAZ);
+            assertEquals(subBuilder.getEnumField(), org.capnproto.test.Test.TestEnum.BAZ);
 
             PrimitiveList.Boolean.Builder boolList = subBuilder.getBoolList();
-            Assertions.assertEquals(boolList.get(0), false);
-            Assertions.assertEquals(boolList.get(1), true);
-            Assertions.assertEquals(boolList.get(2), false);
-            Assertions.assertEquals(boolList.get(3), true);
-            Assertions.assertEquals(boolList.get(4), true);
+            assertEquals(boolList.get(0), false);
+            assertEquals(boolList.get(1), true);
+            assertEquals(boolList.get(2), false);
+            assertEquals(boolList.get(3), true);
+            assertEquals(boolList.get(4), true);
 
         }
-        Assertions.assertEquals(builder.getEnumField(), org.capnproto.test.Test.TestEnum.CORGE);
+        assertEquals(builder.getEnumField(), org.capnproto.test.Test.TestEnum.CORGE);
 
-        Assertions.assertEquals(builder.getVoidList().size(), 6);
+        assertEquals(builder.getVoidList().size(), 6);
 
         PrimitiveList.Boolean.Builder boolList = builder.getBoolList();
-        Assertions.assertEquals(boolList.get(0), true);
-        Assertions.assertEquals(boolList.get(1), false);
-        Assertions.assertEquals(boolList.get(2), false);
-        Assertions.assertEquals(boolList.get(3), true);
+        assertEquals(boolList.get(0), true);
+        assertEquals(boolList.get(1), false);
+        assertEquals(boolList.get(2), false);
+        assertEquals(boolList.get(3), true);
 
         PrimitiveList.Double.Builder float64List = builder.getFloat64List();
-        Assertions.assertEquals(float64List.get(0), 7777.75, DELTA);
-        Assertions.assertEquals(float64List.get(1), Double.POSITIVE_INFINITY, DELTA);
-        Assertions.assertEquals(float64List.get(2), Double.NEGATIVE_INFINITY, DELTA);
-        Assertions.assertEquals(float64List.get(3), Double.NaN, DELTA);
+        assertEquals(float64List.get(0), 7777.75, DELTA);
+        assertEquals(float64List.get(1), Double.POSITIVE_INFINITY, DELTA);
+        assertEquals(float64List.get(2), Double.NEGATIVE_INFINITY, DELTA);
+        assertEquals(float64List.get(3), Double.NaN, DELTA);
 
         TextList.Builder textList = builder.getTextList();
-        Assertions.assertEquals(textList.size(), 3);
-        Assertions.assertEquals(textList.get(0).toString(), "plugh");
-        Assertions.assertEquals(textList.get(1).toString(), "xyzzy");
-        Assertions.assertEquals(textList.get(2).toString(), "thud");
+        assertEquals(textList.size(), 3);
+        assertEquals(textList.get(0).toString(), "plugh");
+        assertEquals(textList.get(1).toString(), "xyzzy");
+        assertEquals(textList.get(2).toString(), "thud");
 
         StructList.Builder<org.capnproto.test.Test.TestAllTypes.Builder> structList = builder.getStructList();
-        Assertions.assertEquals(3, structList.size());
-        Assertions.assertEquals(structList.get(0).getTextField().toString(), "structlist 1");
-        Assertions.assertEquals(structList.get(1).getTextField().toString(), "structlist 2");
-        Assertions.assertEquals(structList.get(2).getTextField().toString(), "structlist 3");
+        assertEquals(3, structList.size());
+        assertEquals(structList.get(0).getTextField().toString(), "structlist 1");
+        assertEquals(structList.get(1).getTextField().toString(), "structlist 2");
+        assertEquals(structList.get(2).getTextField().toString(), "structlist 3");
 
         EnumList.Builder<org.capnproto.test.Test.TestEnum> enumList = builder.getEnumList();
-        Assertions.assertEquals(enumList.get(0), org.capnproto.test.Test.TestEnum.FOO);
-        Assertions.assertEquals(enumList.get(1), org.capnproto.test.Test.TestEnum.GARPLY);
+        assertEquals(enumList.get(0), org.capnproto.test.Test.TestEnum.FOO);
+        assertEquals(enumList.get(1), org.capnproto.test.Test.TestEnum.GARPLY);
     }
 
     public static void checkTestMessage(org.capnproto.test.Test.TestAllTypes.Reader reader) {
         reader.getVoidField();
-        Assertions.assertEquals(reader.getBoolField(), true);
-        Assertions.assertEquals(reader.getInt8Field(), -123);
-        Assertions.assertEquals(reader.getInt16Field(), -12345);
-        Assertions.assertEquals(reader.getInt32Field(), -12345678);
-        Assertions.assertEquals(reader.getInt64Field(), -123456789012345L);
-        Assertions.assertEquals(reader.getUInt8Field(), (byte)0xea);
-        Assertions.assertEquals(reader.getUInt16Field(), 0x4567);
-        Assertions.assertEquals(reader.getUInt32Field(), 0x34567890);
-        Assertions.assertEquals(reader.getUInt64Field(), 0x1234567890123456L);
-        Assertions.assertEquals(reader.getFloat32Field(), 1234.5f, DELTA);
-        Assertions.assertEquals(reader.getFloat64Field(), -123e45, DELTA);
-        Assertions.assertEquals(reader.getTextField().toString(), "foo");
+        assertEquals(reader.getBoolField(), true);
+        assertEquals(reader.getInt8Field(), -123);
+        assertEquals(reader.getInt16Field(), -12345);
+        assertEquals(reader.getInt32Field(), -12345678);
+        assertEquals(reader.getInt64Field(), -123456789012345L);
+        assertEquals(reader.getUInt8Field(), (byte)0xea);
+        assertEquals(reader.getUInt16Field(), 0x4567);
+        assertEquals(reader.getUInt32Field(), 0x34567890);
+        assertEquals(reader.getUInt64Field(), 0x1234567890123456L);
+        assertEquals(reader.getFloat32Field(), 1234.5f, DELTA);
+        assertEquals(reader.getFloat64Field(), -123e45, DELTA);
+        assertEquals(reader.getTextField().toString(), "foo");
 
         {
             org.capnproto.test.Test.TestAllTypes.Reader subReader = reader.getStructField();
             subReader.getVoidField();
-            Assertions.assertEquals(subReader.getBoolField(), true);
-            Assertions.assertEquals(subReader.getInt8Field(), -12);
-            Assertions.assertEquals(subReader.getInt16Field(), 3456);
-            Assertions.assertEquals(subReader.getInt32Field(), -78901234);
-            Assertions.assertEquals(subReader.getInt64Field(), 56789012345678L);
-            Assertions.assertEquals(subReader.getUInt8Field(), 90);
-            Assertions.assertEquals(subReader.getUInt16Field(), 1234);
-            Assertions.assertEquals(subReader.getUInt32Field(), 56789012);
-            Assertions.assertEquals(subReader.getUInt64Field(), 345678901234567890L);
-            Assertions.assertEquals(subReader.getFloat32Field(), -1.25e-10f, DELTA);
-            Assertions.assertEquals(subReader.getFloat64Field(), 345, DELTA);
+            assertEquals(subReader.getBoolField(), true);
+            assertEquals(subReader.getInt8Field(), -12);
+            assertEquals(subReader.getInt16Field(), 3456);
+            assertEquals(subReader.getInt32Field(), -78901234);
+            assertEquals(subReader.getInt64Field(), 56789012345678L);
+            assertEquals(subReader.getUInt8Field(), 90);
+            assertEquals(subReader.getUInt16Field(), 1234);
+            assertEquals(subReader.getUInt32Field(), 56789012);
+            assertEquals(subReader.getUInt64Field(), 345678901234567890L);
+            assertEquals(subReader.getFloat32Field(), -1.25e-10f, DELTA);
+            assertEquals(subReader.getFloat64Field(), 345, DELTA);
 
             {
                 org.capnproto.test.Test.TestAllTypes.Reader subSubReader = subReader.getStructField();
-                Assertions.assertEquals(subSubReader.getTextField().toString(), "nested");
+                assertEquals(subSubReader.getTextField().toString(), "nested");
             }
             PrimitiveList.Boolean.Reader boolList = subReader.getBoolList();
-            Assertions.assertEquals(boolList.get(0), false);
-            Assertions.assertEquals(boolList.get(1), true);
-            Assertions.assertEquals(boolList.get(2), false);
-            Assertions.assertEquals(boolList.get(3), true);
-            Assertions.assertEquals(boolList.get(4), true);
+            assertEquals(boolList.get(0), false);
+            assertEquals(boolList.get(1), true);
+            assertEquals(boolList.get(2), false);
+            assertEquals(boolList.get(3), true);
+            assertEquals(boolList.get(4), true);
 
         }
 
-        Assertions.assertEquals(reader.getVoidList().size(), 6);
+        assertEquals(reader.getVoidList().size(), 6);
 
         PrimitiveList.Boolean.Reader boolList = reader.getBoolList();
-        Assertions.assertEquals(boolList.get(0), true);
-        Assertions.assertEquals(boolList.get(1), false);
-        Assertions.assertEquals(boolList.get(2), false);
-        Assertions.assertEquals(boolList.get(3), true);
+        assertEquals(boolList.get(0), true);
+        assertEquals(boolList.get(1), false);
+        assertEquals(boolList.get(2), false);
+        assertEquals(boolList.get(3), true);
 
         PrimitiveList.Double.Reader float64List = reader.getFloat64List();
-        Assertions.assertEquals(float64List.get(0), 7777.75, DELTA);
-        Assertions.assertEquals(float64List.get(1), Double.POSITIVE_INFINITY, DELTA);
-        Assertions.assertEquals(float64List.get(2), Double.NEGATIVE_INFINITY, DELTA);
-        Assertions.assertEquals(float64List.get(3), Double.NaN, DELTA);
+        assertEquals(float64List.get(0), 7777.75, DELTA);
+        assertEquals(float64List.get(1), Double.POSITIVE_INFINITY, DELTA);
+        assertEquals(float64List.get(2), Double.NEGATIVE_INFINITY, DELTA);
+        assertEquals(float64List.get(3), Double.NaN, DELTA);
 
         TextList.Reader textList = reader.getTextList();
-        Assertions.assertEquals(textList.size(), 3);
-        Assertions.assertEquals(textList.get(0).toString(), "plugh");
-        Assertions.assertEquals(textList.get(1).toString(), "xyzzy");
-        Assertions.assertEquals(textList.get(2).toString(), "thud");
+        assertEquals(textList.size(), 3);
+        assertEquals(textList.get(0).toString(), "plugh");
+        assertEquals(textList.get(1).toString(), "xyzzy");
+        assertEquals(textList.get(2).toString(), "thud");
         StructList.Reader<org.capnproto.test.Test.TestAllTypes.Reader> structList = reader.getStructList();
-        Assertions.assertEquals(3, structList.size());
-        Assertions.assertEquals(structList.get(0).getTextField().toString(), "structlist 1");
-        Assertions.assertEquals(structList.get(1).getTextField().toString(), "structlist 2");
-        Assertions.assertEquals(structList.get(2).getTextField().toString(), "structlist 3");
+        assertEquals(3, structList.size());
+        assertEquals(structList.get(0).getTextField().toString(), "structlist 1");
+        assertEquals(structList.get(1).getTextField().toString(), "structlist 2");
+        assertEquals(structList.get(2).getTextField().toString(), "structlist 3");
 
         EnumList.Reader<org.capnproto.test.Test.TestEnum> enumList = reader.getEnumList();
-        Assertions.assertEquals(enumList.get(0), org.capnproto.test.Test.TestEnum.FOO);
-        Assertions.assertEquals(enumList.get(1), org.capnproto.test.Test.TestEnum.GARPLY);
+        assertEquals(enumList.get(0), org.capnproto.test.Test.TestEnum.FOO);
+        assertEquals(enumList.get(1), org.capnproto.test.Test.TestEnum.GARPLY);
     }
 
     public static void checkDefaultMessage(org.capnproto.test.Test.TestDefaults.Builder builder) {
         builder.getVoidField();
-        Assertions.assertTrue(builder.getBoolField());
-        Assertions.assertEquals(builder.getInt8Field(), -123);
-        Assertions.assertEquals(builder.getInt16Field(), -12345);
-        Assertions.assertEquals(builder.getInt32Field(), -12345678);
-        Assertions.assertEquals(builder.getInt64Field(), -123456789012345L);
-        Assertions.assertEquals(builder.getUInt8Field(), (byte)0xea);
-        Assertions.assertEquals(builder.getUInt16Field(), (short)45678);
-        Assertions.assertEquals(builder.getUInt32Field(), 0xce0a6a14);
-        Assertions.assertEquals(builder.getUInt64Field(), 0xab54a98ceb1f0ad2L);
-        Assertions.assertEquals(builder.getFloat32Field(), 1234.5f, DELTA);
-        Assertions.assertEquals(builder.getFloat64Field(), -123e45, DELTA);
-        Assertions.assertEquals(builder.getEnumField(), org.capnproto.test.Test.TestEnum.CORGE);
+        assertTrue(builder.getBoolField());
+        assertEquals(builder.getInt8Field(), -123);
+        assertEquals(builder.getInt16Field(), -12345);
+        assertEquals(builder.getInt32Field(), -12345678);
+        assertEquals(builder.getInt64Field(), -123456789012345L);
+        assertEquals(builder.getUInt8Field(), (byte)0xea);
+        assertEquals(builder.getUInt16Field(), (short)45678);
+        assertEquals(builder.getUInt32Field(), 0xce0a6a14);
+        assertEquals(builder.getUInt64Field(), 0xab54a98ceb1f0ad2L);
+        assertEquals(builder.getFloat32Field(), 1234.5f, DELTA);
+        assertEquals(builder.getFloat64Field(), -123e45, DELTA);
+        assertEquals(builder.getEnumField(), org.capnproto.test.Test.TestEnum.CORGE);
 
-        Assertions.assertEquals(builder.getTextField().toString(), "foo");
-        Assertions.assertArrayEquals(builder.getDataField().toArray(), new byte[]{0x62, 0x61, 0x72});
+        assertEquals(builder.getTextField().toString(), "foo");
+        assertArrayEquals(builder.getDataField().toArray(), new byte[]{0x62, 0x61, 0x72});
     }
 
     public static void checkDefaultMessage(org.capnproto.test.Test.TestDefaults.Reader reader) {
         reader.getVoidField();
-        Assertions.assertEquals(reader.getBoolField(), true);
-        Assertions.assertEquals(reader.getInt8Field(), -123);
-        Assertions.assertEquals(reader.getInt16Field(), -12345);
-        Assertions.assertEquals(reader.getInt32Field(), -12345678);
-        Assertions.assertEquals(reader.getInt64Field(), -123456789012345L);
-        Assertions.assertEquals(reader.getUInt8Field(), (byte)0xea);
-        Assertions.assertEquals(reader.getUInt16Field(), (short)45678);
-        Assertions.assertEquals(reader.getUInt32Field(), 0xce0a6a14);
-        Assertions.assertEquals(reader.getUInt64Field(), 0xab54a98ceb1f0ad2L);
-        Assertions.assertEquals(reader.getFloat32Field(), 1234.5f, DELTA);
-        Assertions.assertEquals(reader.getFloat64Field(), -123e45, DELTA);
-        Assertions.assertEquals(reader.getTextField().toString(), "foo");
-        Assertions.assertArrayEquals(reader.getDataField().toArray(), new byte[]{0x62, 0x61, 0x72});
+        assertEquals(reader.getBoolField(), true);
+        assertEquals(reader.getInt8Field(), -123);
+        assertEquals(reader.getInt16Field(), -12345);
+        assertEquals(reader.getInt32Field(), -12345678);
+        assertEquals(reader.getInt64Field(), -123456789012345L);
+        assertEquals(reader.getUInt8Field(), (byte)0xea);
+        assertEquals(reader.getUInt16Field(), (short)45678);
+        assertEquals(reader.getUInt32Field(), 0xce0a6a14);
+        assertEquals(reader.getUInt64Field(), 0xab54a98ceb1f0ad2L);
+        assertEquals(reader.getFloat32Field(), 1234.5f, DELTA);
+        assertEquals(reader.getFloat64Field(), -123e45, DELTA);
+        assertEquals(reader.getTextField().toString(), "foo");
+        assertArrayEquals(reader.getDataField().toArray(), new byte[]{0x62, 0x61, 0x72});
         {
             org.capnproto.test.Test.TestAllTypes.Reader subReader = reader.getStructField();
             subReader.getVoidField();
-            Assertions.assertTrue(subReader.getBoolField());
-            Assertions.assertEquals(subReader.getInt8Field(), -12);
-            Assertions.assertEquals(subReader.getInt16Field(), 3456);
-            Assertions.assertEquals(subReader.getInt32Field(), -78901234);
+            assertTrue(subReader.getBoolField());
+            assertEquals(subReader.getInt8Field(), -12);
+            assertEquals(subReader.getInt16Field(), 3456);
+            assertEquals(subReader.getInt32Field(), -78901234);
             // ...
-            Assertions.assertEquals(subReader.getTextField().toString(), "baz");
+            assertEquals(subReader.getTextField().toString(), "baz");
 
             {
                 org.capnproto.test.Test.TestAllTypes.Reader subSubReader = subReader.getStructField();
-                Assertions.assertEquals(subSubReader.getTextField().toString(), "nested");
+                assertEquals(subSubReader.getTextField().toString(), "nested");
             }
 
         }
 
-        Assertions.assertEquals(reader.getEnumField(), org.capnproto.test.Test.TestEnum.CORGE);
-        Assertions.assertEquals(reader.getVoidList().size(), 6);
+        assertEquals(reader.getEnumField(), org.capnproto.test.Test.TestEnum.CORGE);
+        assertEquals(reader.getVoidList().size(), 6);
 
         {
             PrimitiveList.Boolean.Reader listReader = reader.getBoolList();
-            Assertions.assertEquals(listReader.size(), 4);
-            Assertions.assertTrue(listReader.get(0));
-            Assertions.assertFalse(listReader.get(1));
-            Assertions.assertFalse(listReader.get(2));
-            Assertions.assertTrue(listReader.get(3));
+            assertEquals(listReader.size(), 4);
+            assertTrue(listReader.get(0));
+            assertFalse(listReader.get(1));
+            assertFalse(listReader.get(2));
+            assertTrue(listReader.get(3));
         }
 
         {
             PrimitiveList.Byte.Reader listReader = reader.getInt8List();
-            Assertions.assertEquals(listReader.size(), 2);
-            Assertions.assertEquals(listReader.get(0), 111);
-            Assertions.assertEquals(listReader.get(1), -111);
+            assertEquals(listReader.size(), 2);
+            assertEquals(listReader.get(0), 111);
+            assertEquals(listReader.get(1), -111);
         }
     }
 
@@ -332,17 +338,17 @@ public class TestUtil {
     }
 
     public static void checkSettedDefaultMessage(org.capnproto.test.Test.TestDefaults.Reader reader) {
-        Assertions.assertEquals(reader.getBoolField(), false);
-        Assertions.assertEquals(reader.getInt8Field(), -122);
-        Assertions.assertEquals(reader.getInt16Field(), -12344);
-        Assertions.assertEquals(reader.getInt32Field(), -12345677);
-        Assertions.assertEquals(reader.getInt64Field(), -123456789012344L);
-        Assertions.assertEquals(reader.getUInt8Field(), (byte) 0xe9);
-        Assertions.assertEquals(reader.getUInt16Field(), (short) 45677);
-        Assertions.assertEquals(reader.getUInt32Field(), 0xce0a6a13);
-        Assertions.assertEquals(reader.getUInt64Field(), 0xab54a98ceb1f0ad1L);
-        Assertions.assertEquals(reader.getFloat32Field(), 1234.4f, DELTA);
-        Assertions.assertEquals(reader.getFloat64Field(), -123e44, DELTA);
-        Assertions.assertEquals(reader.getEnumField(), org.capnproto.test.Test.TestEnum.QUX);
+        assertEquals(reader.getBoolField(), false);
+        assertEquals(reader.getInt8Field(), -122);
+        assertEquals(reader.getInt16Field(), -12344);
+        assertEquals(reader.getInt32Field(), -12345677);
+        assertEquals(reader.getInt64Field(), -123456789012344L);
+        assertEquals(reader.getUInt8Field(), (byte) 0xe9);
+        assertEquals(reader.getUInt16Field(), (short) 45677);
+        assertEquals(reader.getUInt32Field(), 0xce0a6a13);
+        assertEquals(reader.getUInt64Field(), 0xab54a98ceb1f0ad1L);
+        assertEquals(reader.getFloat32Field(), 1234.4f, DELTA);
+        assertEquals(reader.getFloat64Field(), -123e44, DELTA);
+        assertEquals(reader.getEnumField(), org.capnproto.test.Test.TestEnum.QUX);
     }
 }

--- a/compiler/src/test/java/org/capnproto/test/TestUtil.java
+++ b/compiler/src/test/java/org/capnproto/test/TestUtil.java
@@ -1,7 +1,7 @@
 package org.capnproto.test;
 
 import org.capnproto.*;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.io.UnsupportedEncodingException;
 
@@ -10,14 +10,14 @@ public class TestUtil {
         try {
             return string.getBytes("ISO_8859-1");
         } catch (UnsupportedEncodingException e) {
-            Assert.fail("Could not decode");
+            Assertions.fail("Could not decode");
             return null;
         }
     }
 
     public static final double DELTA = 1e-15;
 
-    public static void initTestMessage(Test.TestAllTypes.Builder builder) {
+    public static void initTestMessage(org.capnproto.test.Test.TestAllTypes.Builder builder) {
         builder.setVoidField(org.capnproto.Void.VOID);
         builder.setBoolField(true);
         builder.setInt8Field((byte) -123);
@@ -33,7 +33,7 @@ public class TestUtil {
         builder.setTextField("foo");
         builder.setDataField(data("bar"));
         {
-            Test.TestAllTypes.Builder subBuilder = builder.initStructField();
+            org.capnproto.test.Test.TestAllTypes.Builder subBuilder = builder.initStructField();
             subBuilder.setVoidField(org.capnproto.Void.VOID);
             subBuilder.setBoolField(true);
             subBuilder.setInt8Field((byte) -12);
@@ -49,11 +49,11 @@ public class TestUtil {
             subBuilder.setTextField(new Text.Reader("baz"));
             subBuilder.setDataField(data("qux"));
             {
-                Test.TestAllTypes.Builder subSubBuilder = subBuilder.initStructField();
+                org.capnproto.test.Test.TestAllTypes.Builder subSubBuilder = subBuilder.initStructField();
                 subSubBuilder.setTextField(new Text.Reader("nested"));
                 subSubBuilder.initStructField().setTextField(new Text.Reader("really nested"));
             }
-            subBuilder.setEnumField(Test.TestEnum.BAZ);
+            subBuilder.setEnumField(org.capnproto.test.Test.TestEnum.BAZ);
 
             PrimitiveList.Boolean.Builder boolList = subBuilder.initBoolList(5);
             boolList.set(0, false);
@@ -63,7 +63,7 @@ public class TestUtil {
             boolList.set(4, true);
         }
 
-        builder.setEnumField(Test.TestEnum.CORGE);
+        builder.setEnumField(org.capnproto.test.Test.TestEnum.CORGE);
         builder.initVoidList(6);
 
         PrimitiveList.Boolean.Builder boolList = builder.initBoolList(4);
@@ -83,239 +83,239 @@ public class TestUtil {
         textList.set(1, new Text.Reader("xyzzy"));
         textList.set(2, new Text.Reader("thud"));
 
-        StructList.Builder<Test.TestAllTypes.Builder> structList = builder.initStructList(3);
+        StructList.Builder<org.capnproto.test.Test.TestAllTypes.Builder> structList = builder.initStructList(3);
         structList.get(0).setTextField(new Text.Reader("structlist 1"));
         structList.get(1).setTextField(new Text.Reader("structlist 2"));
         structList.get(2).setTextField(new Text.Reader("structlist 3"));
 
-        EnumList.Builder<Test.TestEnum> enumList = builder.initEnumList(2);
-        enumList.set(0, Test.TestEnum.FOO);
-        enumList.set(1, Test.TestEnum.GARPLY);
+        EnumList.Builder<org.capnproto.test.Test.TestEnum> enumList = builder.initEnumList(2);
+        enumList.set(0, org.capnproto.test.Test.TestEnum.FOO);
+        enumList.set(1, org.capnproto.test.Test.TestEnum.GARPLY);
     }
 
-    public static void checkTestMessage(Test.TestAllTypes.Builder builder) {
+    public static void checkTestMessage(org.capnproto.test.Test.TestAllTypes.Builder builder) {
         builder.getVoidField();
-        Assert.assertEquals(builder.getBoolField(), true);
-        Assert.assertEquals(builder.getInt8Field(), -123);
-        Assert.assertEquals(builder.getInt16Field(), -12345);
-        Assert.assertEquals(builder.getInt32Field(), -12345678);
-        Assert.assertEquals(builder.getInt64Field(), -123456789012345L);
-        Assert.assertEquals(builder.getUInt8Field(), (byte) 0xea);
-        Assert.assertEquals(builder.getUInt16Field(), 0x4567);
-        Assert.assertEquals(builder.getUInt32Field(), 0x34567890);
-        Assert.assertEquals(builder.getUInt64Field(), 0x1234567890123456L);
-        Assert.assertEquals(builder.getFloat32Field(), 1234.5f, DELTA);
-        Assert.assertEquals(builder.getFloat64Field(), -123e45, DELTA);
-        Assert.assertEquals(builder.getTextField().toString(), "foo");
+        Assertions.assertEquals(builder.getBoolField(), true);
+        Assertions.assertEquals(builder.getInt8Field(), -123);
+        Assertions.assertEquals(builder.getInt16Field(), -12345);
+        Assertions.assertEquals(builder.getInt32Field(), -12345678);
+        Assertions.assertEquals(builder.getInt64Field(), -123456789012345L);
+        Assertions.assertEquals(builder.getUInt8Field(), (byte) 0xea);
+        Assertions.assertEquals(builder.getUInt16Field(), 0x4567);
+        Assertions.assertEquals(builder.getUInt32Field(), 0x34567890);
+        Assertions.assertEquals(builder.getUInt64Field(), 0x1234567890123456L);
+        Assertions.assertEquals(builder.getFloat32Field(), 1234.5f, DELTA);
+        Assertions.assertEquals(builder.getFloat64Field(), -123e45, DELTA);
+        Assertions.assertEquals(builder.getTextField().toString(), "foo");
 
         {
-            Test.TestAllTypes.Builder subBuilder = builder.getStructField();
+            org.capnproto.test.Test.TestAllTypes.Builder subBuilder = builder.getStructField();
             subBuilder.getVoidField();
-            Assert.assertEquals(subBuilder.getBoolField(), true);
-            Assert.assertEquals(subBuilder.getInt8Field(), -12);
-            Assert.assertEquals(subBuilder.getInt16Field(), 3456);
-            Assert.assertEquals(subBuilder.getInt32Field(), -78901234);
-            Assert.assertEquals(subBuilder.getInt64Field(), 56789012345678L);
-            Assert.assertEquals(subBuilder.getUInt8Field(), 90);
-            Assert.assertEquals(subBuilder.getUInt16Field(), 1234);
-            Assert.assertEquals(subBuilder.getUInt32Field(), 56789012);
-            Assert.assertEquals(subBuilder.getUInt64Field(), 345678901234567890L);
-            Assert.assertEquals(subBuilder.getFloat32Field(), -1.25e-10f, DELTA);
-            Assert.assertEquals(subBuilder.getFloat64Field(), 345, DELTA);
+            Assertions.assertEquals(subBuilder.getBoolField(), true);
+            Assertions.assertEquals(subBuilder.getInt8Field(), -12);
+            Assertions.assertEquals(subBuilder.getInt16Field(), 3456);
+            Assertions.assertEquals(subBuilder.getInt32Field(), -78901234);
+            Assertions.assertEquals(subBuilder.getInt64Field(), 56789012345678L);
+            Assertions.assertEquals(subBuilder.getUInt8Field(), 90);
+            Assertions.assertEquals(subBuilder.getUInt16Field(), 1234);
+            Assertions.assertEquals(subBuilder.getUInt32Field(), 56789012);
+            Assertions.assertEquals(subBuilder.getUInt64Field(), 345678901234567890L);
+            Assertions.assertEquals(subBuilder.getFloat32Field(), -1.25e-10f, DELTA);
+            Assertions.assertEquals(subBuilder.getFloat64Field(), 345, DELTA);
 
             {
-                Test.TestAllTypes.Builder subSubBuilder = subBuilder.getStructField();
-                Assert.assertEquals(subSubBuilder.getTextField().toString(), "nested");
+                org.capnproto.test.Test.TestAllTypes.Builder subSubBuilder = subBuilder.getStructField();
+                Assertions.assertEquals(subSubBuilder.getTextField().toString(), "nested");
             }
 
-            Assert.assertEquals(subBuilder.getEnumField(), Test.TestEnum.BAZ);
+            Assertions.assertEquals(subBuilder.getEnumField(), org.capnproto.test.Test.TestEnum.BAZ);
 
             PrimitiveList.Boolean.Builder boolList = subBuilder.getBoolList();
-            Assert.assertEquals(boolList.get(0), false);
-            Assert.assertEquals(boolList.get(1), true);
-            Assert.assertEquals(boolList.get(2), false);
-            Assert.assertEquals(boolList.get(3), true);
-            Assert.assertEquals(boolList.get(4), true);
+            Assertions.assertEquals(boolList.get(0), false);
+            Assertions.assertEquals(boolList.get(1), true);
+            Assertions.assertEquals(boolList.get(2), false);
+            Assertions.assertEquals(boolList.get(3), true);
+            Assertions.assertEquals(boolList.get(4), true);
 
         }
-        Assert.assertEquals(builder.getEnumField(), Test.TestEnum.CORGE);
+        Assertions.assertEquals(builder.getEnumField(), org.capnproto.test.Test.TestEnum.CORGE);
 
-        Assert.assertEquals(builder.getVoidList().size(), 6);
+        Assertions.assertEquals(builder.getVoidList().size(), 6);
 
         PrimitiveList.Boolean.Builder boolList = builder.getBoolList();
-        Assert.assertEquals(boolList.get(0), true);
-        Assert.assertEquals(boolList.get(1), false);
-        Assert.assertEquals(boolList.get(2), false);
-        Assert.assertEquals(boolList.get(3), true);
+        Assertions.assertEquals(boolList.get(0), true);
+        Assertions.assertEquals(boolList.get(1), false);
+        Assertions.assertEquals(boolList.get(2), false);
+        Assertions.assertEquals(boolList.get(3), true);
 
         PrimitiveList.Double.Builder float64List = builder.getFloat64List();
-        Assert.assertEquals(float64List.get(0), 7777.75, DELTA);
-        Assert.assertEquals(float64List.get(1), Double.POSITIVE_INFINITY, DELTA);
-        Assert.assertEquals(float64List.get(2), Double.NEGATIVE_INFINITY, DELTA);
-        Assert.assertEquals(float64List.get(3), Double.NaN, DELTA);
+        Assertions.assertEquals(float64List.get(0), 7777.75, DELTA);
+        Assertions.assertEquals(float64List.get(1), Double.POSITIVE_INFINITY, DELTA);
+        Assertions.assertEquals(float64List.get(2), Double.NEGATIVE_INFINITY, DELTA);
+        Assertions.assertEquals(float64List.get(3), Double.NaN, DELTA);
 
         TextList.Builder textList = builder.getTextList();
-        Assert.assertEquals(textList.size(), 3);
-        Assert.assertEquals(textList.get(0).toString(), "plugh");
-        Assert.assertEquals(textList.get(1).toString(), "xyzzy");
-        Assert.assertEquals(textList.get(2).toString(), "thud");
+        Assertions.assertEquals(textList.size(), 3);
+        Assertions.assertEquals(textList.get(0).toString(), "plugh");
+        Assertions.assertEquals(textList.get(1).toString(), "xyzzy");
+        Assertions.assertEquals(textList.get(2).toString(), "thud");
 
-        StructList.Builder<Test.TestAllTypes.Builder> structList = builder.getStructList();
-        Assert.assertEquals(3, structList.size());
-        Assert.assertEquals(structList.get(0).getTextField().toString(), "structlist 1");
-        Assert.assertEquals(structList.get(1).getTextField().toString(), "structlist 2");
-        Assert.assertEquals(structList.get(2).getTextField().toString(), "structlist 3");
+        StructList.Builder<org.capnproto.test.Test.TestAllTypes.Builder> structList = builder.getStructList();
+        Assertions.assertEquals(3, structList.size());
+        Assertions.assertEquals(structList.get(0).getTextField().toString(), "structlist 1");
+        Assertions.assertEquals(structList.get(1).getTextField().toString(), "structlist 2");
+        Assertions.assertEquals(structList.get(2).getTextField().toString(), "structlist 3");
 
-        EnumList.Builder<Test.TestEnum> enumList = builder.getEnumList();
-        Assert.assertEquals(enumList.get(0), Test.TestEnum.FOO);
-        Assert.assertEquals(enumList.get(1), Test.TestEnum.GARPLY);
+        EnumList.Builder<org.capnproto.test.Test.TestEnum> enumList = builder.getEnumList();
+        Assertions.assertEquals(enumList.get(0), org.capnproto.test.Test.TestEnum.FOO);
+        Assertions.assertEquals(enumList.get(1), org.capnproto.test.Test.TestEnum.GARPLY);
     }
 
-    public static void checkTestMessage(Test.TestAllTypes.Reader reader) {
+    public static void checkTestMessage(org.capnproto.test.Test.TestAllTypes.Reader reader) {
         reader.getVoidField();
-        Assert.assertEquals(reader.getBoolField(), true);
-        Assert.assertEquals(reader.getInt8Field(), -123);
-        Assert.assertEquals(reader.getInt16Field(), -12345);
-        Assert.assertEquals(reader.getInt32Field(), -12345678);
-        Assert.assertEquals(reader.getInt64Field(), -123456789012345L);
-        Assert.assertEquals(reader.getUInt8Field(), (byte)0xea);
-        Assert.assertEquals(reader.getUInt16Field(), 0x4567);
-        Assert.assertEquals(reader.getUInt32Field(), 0x34567890);
-        Assert.assertEquals(reader.getUInt64Field(), 0x1234567890123456L);
-        Assert.assertEquals(reader.getFloat32Field(), 1234.5f, DELTA);
-        Assert.assertEquals(reader.getFloat64Field(), -123e45, DELTA);
-        Assert.assertEquals(reader.getTextField().toString(), "foo");
+        Assertions.assertEquals(reader.getBoolField(), true);
+        Assertions.assertEquals(reader.getInt8Field(), -123);
+        Assertions.assertEquals(reader.getInt16Field(), -12345);
+        Assertions.assertEquals(reader.getInt32Field(), -12345678);
+        Assertions.assertEquals(reader.getInt64Field(), -123456789012345L);
+        Assertions.assertEquals(reader.getUInt8Field(), (byte)0xea);
+        Assertions.assertEquals(reader.getUInt16Field(), 0x4567);
+        Assertions.assertEquals(reader.getUInt32Field(), 0x34567890);
+        Assertions.assertEquals(reader.getUInt64Field(), 0x1234567890123456L);
+        Assertions.assertEquals(reader.getFloat32Field(), 1234.5f, DELTA);
+        Assertions.assertEquals(reader.getFloat64Field(), -123e45, DELTA);
+        Assertions.assertEquals(reader.getTextField().toString(), "foo");
 
         {
-            Test.TestAllTypes.Reader subReader = reader.getStructField();
+            org.capnproto.test.Test.TestAllTypes.Reader subReader = reader.getStructField();
             subReader.getVoidField();
-            Assert.assertEquals(subReader.getBoolField(), true);
-            Assert.assertEquals(subReader.getInt8Field(), -12);
-            Assert.assertEquals(subReader.getInt16Field(), 3456);
-            Assert.assertEquals(subReader.getInt32Field(), -78901234);
-            Assert.assertEquals(subReader.getInt64Field(), 56789012345678L);
-            Assert.assertEquals(subReader.getUInt8Field(), 90);
-            Assert.assertEquals(subReader.getUInt16Field(), 1234);
-            Assert.assertEquals(subReader.getUInt32Field(), 56789012);
-            Assert.assertEquals(subReader.getUInt64Field(), 345678901234567890L);
-            Assert.assertEquals(subReader.getFloat32Field(), -1.25e-10f, DELTA);
-            Assert.assertEquals(subReader.getFloat64Field(), 345, DELTA);
+            Assertions.assertEquals(subReader.getBoolField(), true);
+            Assertions.assertEquals(subReader.getInt8Field(), -12);
+            Assertions.assertEquals(subReader.getInt16Field(), 3456);
+            Assertions.assertEquals(subReader.getInt32Field(), -78901234);
+            Assertions.assertEquals(subReader.getInt64Field(), 56789012345678L);
+            Assertions.assertEquals(subReader.getUInt8Field(), 90);
+            Assertions.assertEquals(subReader.getUInt16Field(), 1234);
+            Assertions.assertEquals(subReader.getUInt32Field(), 56789012);
+            Assertions.assertEquals(subReader.getUInt64Field(), 345678901234567890L);
+            Assertions.assertEquals(subReader.getFloat32Field(), -1.25e-10f, DELTA);
+            Assertions.assertEquals(subReader.getFloat64Field(), 345, DELTA);
 
             {
-                Test.TestAllTypes.Reader subSubReader = subReader.getStructField();
-                Assert.assertEquals(subSubReader.getTextField().toString(), "nested");
+                org.capnproto.test.Test.TestAllTypes.Reader subSubReader = subReader.getStructField();
+                Assertions.assertEquals(subSubReader.getTextField().toString(), "nested");
             }
             PrimitiveList.Boolean.Reader boolList = subReader.getBoolList();
-            Assert.assertEquals(boolList.get(0), false);
-            Assert.assertEquals(boolList.get(1), true);
-            Assert.assertEquals(boolList.get(2), false);
-            Assert.assertEquals(boolList.get(3), true);
-            Assert.assertEquals(boolList.get(4), true);
+            Assertions.assertEquals(boolList.get(0), false);
+            Assertions.assertEquals(boolList.get(1), true);
+            Assertions.assertEquals(boolList.get(2), false);
+            Assertions.assertEquals(boolList.get(3), true);
+            Assertions.assertEquals(boolList.get(4), true);
 
         }
 
-        Assert.assertEquals(reader.getVoidList().size(), 6);
+        Assertions.assertEquals(reader.getVoidList().size(), 6);
 
         PrimitiveList.Boolean.Reader boolList = reader.getBoolList();
-        Assert.assertEquals(boolList.get(0), true);
-        Assert.assertEquals(boolList.get(1), false);
-        Assert.assertEquals(boolList.get(2), false);
-        Assert.assertEquals(boolList.get(3), true);
+        Assertions.assertEquals(boolList.get(0), true);
+        Assertions.assertEquals(boolList.get(1), false);
+        Assertions.assertEquals(boolList.get(2), false);
+        Assertions.assertEquals(boolList.get(3), true);
 
         PrimitiveList.Double.Reader float64List = reader.getFloat64List();
-        Assert.assertEquals(float64List.get(0), 7777.75, DELTA);
-        Assert.assertEquals(float64List.get(1), Double.POSITIVE_INFINITY, DELTA);
-        Assert.assertEquals(float64List.get(2), Double.NEGATIVE_INFINITY, DELTA);
-        Assert.assertEquals(float64List.get(3), Double.NaN, DELTA);
+        Assertions.assertEquals(float64List.get(0), 7777.75, DELTA);
+        Assertions.assertEquals(float64List.get(1), Double.POSITIVE_INFINITY, DELTA);
+        Assertions.assertEquals(float64List.get(2), Double.NEGATIVE_INFINITY, DELTA);
+        Assertions.assertEquals(float64List.get(3), Double.NaN, DELTA);
 
         TextList.Reader textList = reader.getTextList();
-        Assert.assertEquals(textList.size(), 3);
-        Assert.assertEquals(textList.get(0).toString(), "plugh");
-        Assert.assertEquals(textList.get(1).toString(), "xyzzy");
-        Assert.assertEquals(textList.get(2).toString(), "thud");
-        StructList.Reader<Test.TestAllTypes.Reader> structList = reader.getStructList();
-        Assert.assertEquals(3, structList.size());
-        Assert.assertEquals(structList.get(0).getTextField().toString(), "structlist 1");
-        Assert.assertEquals(structList.get(1).getTextField().toString(), "structlist 2");
-        Assert.assertEquals(structList.get(2).getTextField().toString(), "structlist 3");
+        Assertions.assertEquals(textList.size(), 3);
+        Assertions.assertEquals(textList.get(0).toString(), "plugh");
+        Assertions.assertEquals(textList.get(1).toString(), "xyzzy");
+        Assertions.assertEquals(textList.get(2).toString(), "thud");
+        StructList.Reader<org.capnproto.test.Test.TestAllTypes.Reader> structList = reader.getStructList();
+        Assertions.assertEquals(3, structList.size());
+        Assertions.assertEquals(structList.get(0).getTextField().toString(), "structlist 1");
+        Assertions.assertEquals(structList.get(1).getTextField().toString(), "structlist 2");
+        Assertions.assertEquals(structList.get(2).getTextField().toString(), "structlist 3");
 
-        EnumList.Reader<Test.TestEnum> enumList = reader.getEnumList();
-        Assert.assertEquals(enumList.get(0), Test.TestEnum.FOO);
-        Assert.assertEquals(enumList.get(1), Test.TestEnum.GARPLY);
+        EnumList.Reader<org.capnproto.test.Test.TestEnum> enumList = reader.getEnumList();
+        Assertions.assertEquals(enumList.get(0), org.capnproto.test.Test.TestEnum.FOO);
+        Assertions.assertEquals(enumList.get(1), org.capnproto.test.Test.TestEnum.GARPLY);
     }
 
-    public static void checkDefaultMessage(Test.TestDefaults.Builder builder) {
+    public static void checkDefaultMessage(org.capnproto.test.Test.TestDefaults.Builder builder) {
         builder.getVoidField();
-        Assert.assertTrue(builder.getBoolField());
-        Assert.assertEquals(builder.getInt8Field(), -123);
-        Assert.assertEquals(builder.getInt16Field(), -12345);
-        Assert.assertEquals(builder.getInt32Field(), -12345678);
-        Assert.assertEquals(builder.getInt64Field(), -123456789012345L);
-        Assert.assertEquals(builder.getUInt8Field(), (byte)0xea);
-        Assert.assertEquals(builder.getUInt16Field(), (short)45678);
-        Assert.assertEquals(builder.getUInt32Field(), 0xce0a6a14);
-        Assert.assertEquals(builder.getUInt64Field(), 0xab54a98ceb1f0ad2L);
-        Assert.assertEquals(builder.getFloat32Field(), 1234.5f, DELTA);
-        Assert.assertEquals(builder.getFloat64Field(), -123e45, DELTA);
-        Assert.assertEquals(builder.getEnumField(), Test.TestEnum.CORGE);
+        Assertions.assertTrue(builder.getBoolField());
+        Assertions.assertEquals(builder.getInt8Field(), -123);
+        Assertions.assertEquals(builder.getInt16Field(), -12345);
+        Assertions.assertEquals(builder.getInt32Field(), -12345678);
+        Assertions.assertEquals(builder.getInt64Field(), -123456789012345L);
+        Assertions.assertEquals(builder.getUInt8Field(), (byte)0xea);
+        Assertions.assertEquals(builder.getUInt16Field(), (short)45678);
+        Assertions.assertEquals(builder.getUInt32Field(), 0xce0a6a14);
+        Assertions.assertEquals(builder.getUInt64Field(), 0xab54a98ceb1f0ad2L);
+        Assertions.assertEquals(builder.getFloat32Field(), 1234.5f, DELTA);
+        Assertions.assertEquals(builder.getFloat64Field(), -123e45, DELTA);
+        Assertions.assertEquals(builder.getEnumField(), org.capnproto.test.Test.TestEnum.CORGE);
 
-        Assert.assertEquals(builder.getTextField().toString(), "foo");
-        Assert.assertArrayEquals(builder.getDataField().toArray(), new byte[]{0x62, 0x61, 0x72});
+        Assertions.assertEquals(builder.getTextField().toString(), "foo");
+        Assertions.assertArrayEquals(builder.getDataField().toArray(), new byte[]{0x62, 0x61, 0x72});
     }
 
-    public static void checkDefaultMessage(Test.TestDefaults.Reader reader) {
+    public static void checkDefaultMessage(org.capnproto.test.Test.TestDefaults.Reader reader) {
         reader.getVoidField();
-        Assert.assertEquals(reader.getBoolField(), true);
-        Assert.assertEquals(reader.getInt8Field(), -123);
-        Assert.assertEquals(reader.getInt16Field(), -12345);
-        Assert.assertEquals(reader.getInt32Field(), -12345678);
-        Assert.assertEquals(reader.getInt64Field(), -123456789012345L);
-        Assert.assertEquals(reader.getUInt8Field(), (byte)0xea);
-        Assert.assertEquals(reader.getUInt16Field(), (short)45678);
-        Assert.assertEquals(reader.getUInt32Field(), 0xce0a6a14);
-        Assert.assertEquals(reader.getUInt64Field(), 0xab54a98ceb1f0ad2L);
-        Assert.assertEquals(reader.getFloat32Field(), 1234.5f, DELTA);
-        Assert.assertEquals(reader.getFloat64Field(), -123e45, DELTA);
-        Assert.assertEquals(reader.getTextField().toString(), "foo");
-        Assert.assertArrayEquals(reader.getDataField().toArray(), new byte[]{0x62, 0x61, 0x72});
+        Assertions.assertEquals(reader.getBoolField(), true);
+        Assertions.assertEquals(reader.getInt8Field(), -123);
+        Assertions.assertEquals(reader.getInt16Field(), -12345);
+        Assertions.assertEquals(reader.getInt32Field(), -12345678);
+        Assertions.assertEquals(reader.getInt64Field(), -123456789012345L);
+        Assertions.assertEquals(reader.getUInt8Field(), (byte)0xea);
+        Assertions.assertEquals(reader.getUInt16Field(), (short)45678);
+        Assertions.assertEquals(reader.getUInt32Field(), 0xce0a6a14);
+        Assertions.assertEquals(reader.getUInt64Field(), 0xab54a98ceb1f0ad2L);
+        Assertions.assertEquals(reader.getFloat32Field(), 1234.5f, DELTA);
+        Assertions.assertEquals(reader.getFloat64Field(), -123e45, DELTA);
+        Assertions.assertEquals(reader.getTextField().toString(), "foo");
+        Assertions.assertArrayEquals(reader.getDataField().toArray(), new byte[]{0x62, 0x61, 0x72});
         {
-            Test.TestAllTypes.Reader subReader = reader.getStructField();
+            org.capnproto.test.Test.TestAllTypes.Reader subReader = reader.getStructField();
             subReader.getVoidField();
-            Assert.assertTrue(subReader.getBoolField());
-            Assert.assertEquals(subReader.getInt8Field(), -12);
-            Assert.assertEquals(subReader.getInt16Field(), 3456);
-            Assert.assertEquals(subReader.getInt32Field(), -78901234);
+            Assertions.assertTrue(subReader.getBoolField());
+            Assertions.assertEquals(subReader.getInt8Field(), -12);
+            Assertions.assertEquals(subReader.getInt16Field(), 3456);
+            Assertions.assertEquals(subReader.getInt32Field(), -78901234);
             // ...
-            Assert.assertEquals(subReader.getTextField().toString(), "baz");
+            Assertions.assertEquals(subReader.getTextField().toString(), "baz");
 
             {
-                Test.TestAllTypes.Reader subSubReader = subReader.getStructField();
-                Assert.assertEquals(subSubReader.getTextField().toString(), "nested");
+                org.capnproto.test.Test.TestAllTypes.Reader subSubReader = subReader.getStructField();
+                Assertions.assertEquals(subSubReader.getTextField().toString(), "nested");
             }
 
         }
 
-        Assert.assertEquals(reader.getEnumField(), Test.TestEnum.CORGE);
-        Assert.assertEquals(reader.getVoidList().size(), 6);
+        Assertions.assertEquals(reader.getEnumField(), org.capnproto.test.Test.TestEnum.CORGE);
+        Assertions.assertEquals(reader.getVoidList().size(), 6);
 
         {
             PrimitiveList.Boolean.Reader listReader = reader.getBoolList();
-            Assert.assertEquals(listReader.size(), 4);
-            Assert.assertTrue(listReader.get(0));
-            Assert.assertFalse(listReader.get(1));
-            Assert.assertFalse(listReader.get(2));
-            Assert.assertTrue(listReader.get(3));
+            Assertions.assertEquals(listReader.size(), 4);
+            Assertions.assertTrue(listReader.get(0));
+            Assertions.assertFalse(listReader.get(1));
+            Assertions.assertFalse(listReader.get(2));
+            Assertions.assertTrue(listReader.get(3));
         }
 
         {
             PrimitiveList.Byte.Reader listReader = reader.getInt8List();
-            Assert.assertEquals(listReader.size(), 2);
-            Assert.assertEquals(listReader.get(0), 111);
-            Assert.assertEquals(listReader.get(1), -111);
+            Assertions.assertEquals(listReader.size(), 2);
+            Assertions.assertEquals(listReader.get(0), 111);
+            Assertions.assertEquals(listReader.get(1), -111);
         }
     }
 
-    public static void setDefaultMessage(Test.TestDefaults.Builder builder) {
+    public static void setDefaultMessage(org.capnproto.test.Test.TestDefaults.Builder builder) {
         builder.setBoolField(false);
         builder.setInt8Field((byte) -122);
         builder.setInt16Field((short) -12344);
@@ -328,21 +328,21 @@ public class TestUtil {
         builder.setFloat32Field(1234.4f);
         builder.setFloat64Field(-123e44);
         builder.setTextField(new Text.Reader("bar"));
-        builder.setEnumField(Test.TestEnum.QUX);
+        builder.setEnumField(org.capnproto.test.Test.TestEnum.QUX);
     }
 
-    public static void checkSettedDefaultMessage(Test.TestDefaults.Reader reader) {
-        Assert.assertEquals(reader.getBoolField(), false);
-        Assert.assertEquals(reader.getInt8Field(), -122);
-        Assert.assertEquals(reader.getInt16Field(), -12344);
-        Assert.assertEquals(reader.getInt32Field(), -12345677);
-        Assert.assertEquals(reader.getInt64Field(), -123456789012344L);
-        Assert.assertEquals(reader.getUInt8Field(), (byte) 0xe9);
-        Assert.assertEquals(reader.getUInt16Field(), (short) 45677);
-        Assert.assertEquals(reader.getUInt32Field(), 0xce0a6a13);
-        Assert.assertEquals(reader.getUInt64Field(), 0xab54a98ceb1f0ad1L);
-        Assert.assertEquals(reader.getFloat32Field(), 1234.4f, DELTA);
-        Assert.assertEquals(reader.getFloat64Field(), -123e44, DELTA);
-        Assert.assertEquals(reader.getEnumField(), Test.TestEnum.QUX);
+    public static void checkSettedDefaultMessage(org.capnproto.test.Test.TestDefaults.Reader reader) {
+        Assertions.assertEquals(reader.getBoolField(), false);
+        Assertions.assertEquals(reader.getInt8Field(), -122);
+        Assertions.assertEquals(reader.getInt16Field(), -12344);
+        Assertions.assertEquals(reader.getInt32Field(), -12345677);
+        Assertions.assertEquals(reader.getInt64Field(), -123456789012344L);
+        Assertions.assertEquals(reader.getUInt8Field(), (byte) 0xe9);
+        Assertions.assertEquals(reader.getUInt16Field(), (short) 45677);
+        Assertions.assertEquals(reader.getUInt32Field(), 0xce0a6a13);
+        Assertions.assertEquals(reader.getUInt64Field(), 0xab54a98ceb1f0ad1L);
+        Assertions.assertEquals(reader.getFloat32Field(), 1234.4f, DELTA);
+        Assertions.assertEquals(reader.getFloat64Field(), -123e44, DELTA);
+        Assertions.assertEquals(reader.getEnumField(), org.capnproto.test.Test.TestEnum.QUX);
     }
 }

--- a/compiler/src/test/java/org/capnproto/test/TestUtil.java
+++ b/compiler/src/test/java/org/capnproto/test/TestUtil.java
@@ -101,76 +101,76 @@ public class TestUtil {
 
     public static void checkTestMessage(org.capnproto.test.Test.TestAllTypes.Builder builder) {
         builder.getVoidField();
-        assertEquals(builder.getBoolField(), true);
-        assertEquals(builder.getInt8Field(), -123);
-        assertEquals(builder.getInt16Field(), -12345);
-        assertEquals(builder.getInt32Field(), -12345678);
-        assertEquals(builder.getInt64Field(), -123456789012345L);
-        assertEquals(builder.getUInt8Field(), (byte) 0xea);
-        assertEquals(builder.getUInt16Field(), 0x4567);
-        assertEquals(builder.getUInt32Field(), 0x34567890);
-        assertEquals(builder.getUInt64Field(), 0x1234567890123456L);
-        assertEquals(builder.getFloat32Field(), 1234.5f, DELTA);
-        assertEquals(builder.getFloat64Field(), -123e45, DELTA);
-        assertEquals(builder.getTextField().toString(), "foo");
+        assertEquals(true, builder.getBoolField());
+        assertEquals(-123, builder.getInt8Field());
+        assertEquals(-12345, builder.getInt16Field());
+        assertEquals(-12345678, builder.getInt32Field());
+        assertEquals(-123456789012345L, builder.getInt64Field());
+        assertEquals((byte) 0xea, builder.getUInt8Field());
+        assertEquals(0x4567, builder.getUInt16Field());
+        assertEquals(0x34567890, builder.getUInt32Field());
+        assertEquals(0x1234567890123456L, builder.getUInt64Field());
+        assertEquals(1234.5f, builder.getFloat32Field(), DELTA);
+        assertEquals(-123e45, builder.getFloat64Field(), DELTA);
+        assertEquals("foo", builder.getTextField().toString());
 
         {
             org.capnproto.test.Test.TestAllTypes.Builder subBuilder = builder.getStructField();
             subBuilder.getVoidField();
-            assertEquals(subBuilder.getBoolField(), true);
-            assertEquals(subBuilder.getInt8Field(), -12);
-            assertEquals(subBuilder.getInt16Field(), 3456);
-            assertEquals(subBuilder.getInt32Field(), -78901234);
-            assertEquals(subBuilder.getInt64Field(), 56789012345678L);
-            assertEquals(subBuilder.getUInt8Field(), 90);
-            assertEquals(subBuilder.getUInt16Field(), 1234);
-            assertEquals(subBuilder.getUInt32Field(), 56789012);
-            assertEquals(subBuilder.getUInt64Field(), 345678901234567890L);
-            assertEquals(subBuilder.getFloat32Field(), -1.25e-10f, DELTA);
-            assertEquals(subBuilder.getFloat64Field(), 345, DELTA);
+            assertEquals(true, subBuilder.getBoolField());
+            assertEquals(-12, subBuilder.getInt8Field());
+            assertEquals(3456, subBuilder.getInt16Field());
+            assertEquals(-78901234, subBuilder.getInt32Field());
+            assertEquals(56789012345678L, subBuilder.getInt64Field());
+            assertEquals(90, subBuilder.getUInt8Field());
+            assertEquals(1234, subBuilder.getUInt16Field());
+            assertEquals(56789012, subBuilder.getUInt32Field());
+            assertEquals(345678901234567890L, subBuilder.getUInt64Field());
+            assertEquals(-1.25e-10f, subBuilder.getFloat32Field(), DELTA);
+            assertEquals(345, subBuilder.getFloat64Field(), DELTA);
 
             {
                 org.capnproto.test.Test.TestAllTypes.Builder subSubBuilder = subBuilder.getStructField();
-                assertEquals(subSubBuilder.getTextField().toString(), "nested");
+                assertEquals("nested", subSubBuilder.getTextField().toString());
             }
 
             assertEquals(subBuilder.getEnumField(), org.capnproto.test.Test.TestEnum.BAZ);
 
             PrimitiveList.Boolean.Builder boolList = subBuilder.getBoolList();
-            assertEquals(boolList.get(0), false);
-            assertEquals(boolList.get(1), true);
-            assertEquals(boolList.get(2), false);
-            assertEquals(boolList.get(3), true);
-            assertEquals(boolList.get(4), true);
+            assertEquals(false, boolList.get(0));
+            assertEquals(true, boolList.get(1));
+            assertEquals(false, boolList.get(2));
+            assertEquals(true, boolList.get(3));
+            assertEquals(true, boolList.get(4));
 
         }
         assertEquals(builder.getEnumField(), org.capnproto.test.Test.TestEnum.CORGE);
 
-        assertEquals(builder.getVoidList().size(), 6);
+        assertEquals(6, builder.getVoidList().size());
 
         PrimitiveList.Boolean.Builder boolList = builder.getBoolList();
-        assertEquals(boolList.get(0), true);
-        assertEquals(boolList.get(1), false);
-        assertEquals(boolList.get(2), false);
-        assertEquals(boolList.get(3), true);
+        assertEquals(true, boolList.get(0));
+        assertEquals(false, boolList.get(1));
+        assertEquals(false, boolList.get(2));
+        assertEquals(true, boolList.get(3));
 
         PrimitiveList.Double.Builder float64List = builder.getFloat64List();
-        assertEquals(float64List.get(0), 7777.75, DELTA);
-        assertEquals(float64List.get(1), Double.POSITIVE_INFINITY, DELTA);
-        assertEquals(float64List.get(2), Double.NEGATIVE_INFINITY, DELTA);
-        assertEquals(float64List.get(3), Double.NaN, DELTA);
+        assertEquals(7777.75, float64List.get(0), DELTA);
+        assertEquals(Double.POSITIVE_INFINITY, float64List.get(1), DELTA);
+        assertEquals(Double.NEGATIVE_INFINITY, float64List.get(2), DELTA);
+        assertEquals(Double.NaN, float64List.get(3), DELTA);
 
         TextList.Builder textList = builder.getTextList();
-        assertEquals(textList.size(), 3);
-        assertEquals(textList.get(0).toString(), "plugh");
-        assertEquals(textList.get(1).toString(), "xyzzy");
-        assertEquals(textList.get(2).toString(), "thud");
+        assertEquals(3, textList.size());
+        assertEquals("plugh", textList.get(0).toString());
+        assertEquals("xyzzy", textList.get(1).toString());
+        assertEquals("thud", textList.get(2).toString());
 
         StructList.Builder<org.capnproto.test.Test.TestAllTypes.Builder> structList = builder.getStructList();
         assertEquals(3, structList.size());
-        assertEquals(structList.get(0).getTextField().toString(), "structlist 1");
-        assertEquals(structList.get(1).getTextField().toString(), "structlist 2");
-        assertEquals(structList.get(2).getTextField().toString(), "structlist 3");
+        assertEquals("structlist 1", structList.get(0).getTextField().toString());
+        assertEquals("structlist 2", structList.get(1).getTextField().toString());
+        assertEquals("structlist 3", structList.get(2).getTextField().toString());
 
         EnumList.Builder<org.capnproto.test.Test.TestEnum> enumList = builder.getEnumList();
         assertEquals(enumList.get(0), org.capnproto.test.Test.TestEnum.FOO);
@@ -179,71 +179,71 @@ public class TestUtil {
 
     public static void checkTestMessage(org.capnproto.test.Test.TestAllTypes.Reader reader) {
         reader.getVoidField();
-        assertEquals(reader.getBoolField(), true);
-        assertEquals(reader.getInt8Field(), -123);
-        assertEquals(reader.getInt16Field(), -12345);
-        assertEquals(reader.getInt32Field(), -12345678);
-        assertEquals(reader.getInt64Field(), -123456789012345L);
-        assertEquals(reader.getUInt8Field(), (byte)0xea);
-        assertEquals(reader.getUInt16Field(), 0x4567);
-        assertEquals(reader.getUInt32Field(), 0x34567890);
-        assertEquals(reader.getUInt64Field(), 0x1234567890123456L);
-        assertEquals(reader.getFloat32Field(), 1234.5f, DELTA);
-        assertEquals(reader.getFloat64Field(), -123e45, DELTA);
-        assertEquals(reader.getTextField().toString(), "foo");
+        assertEquals(true, reader.getBoolField());
+        assertEquals(-123, reader.getInt8Field());
+        assertEquals(-12345, reader.getInt16Field());
+        assertEquals(-12345678, reader.getInt32Field());
+        assertEquals(-123456789012345L, reader.getInt64Field());
+        assertEquals((byte)0xea, reader.getUInt8Field());
+        assertEquals(0x4567, reader.getUInt16Field());
+        assertEquals(0x34567890, reader.getUInt32Field());
+        assertEquals(0x1234567890123456L, reader.getUInt64Field());
+        assertEquals(1234.5f, reader.getFloat32Field(), DELTA);
+        assertEquals(-123e45, reader.getFloat64Field(), DELTA);
+        assertEquals("foo", reader.getTextField().toString());
 
         {
             org.capnproto.test.Test.TestAllTypes.Reader subReader = reader.getStructField();
             subReader.getVoidField();
-            assertEquals(subReader.getBoolField(), true);
-            assertEquals(subReader.getInt8Field(), -12);
-            assertEquals(subReader.getInt16Field(), 3456);
-            assertEquals(subReader.getInt32Field(), -78901234);
-            assertEquals(subReader.getInt64Field(), 56789012345678L);
-            assertEquals(subReader.getUInt8Field(), 90);
-            assertEquals(subReader.getUInt16Field(), 1234);
-            assertEquals(subReader.getUInt32Field(), 56789012);
-            assertEquals(subReader.getUInt64Field(), 345678901234567890L);
-            assertEquals(subReader.getFloat32Field(), -1.25e-10f, DELTA);
-            assertEquals(subReader.getFloat64Field(), 345, DELTA);
+            assertEquals(true, subReader.getBoolField());
+            assertEquals(-12, subReader.getInt8Field());
+            assertEquals(3456, subReader.getInt16Field());
+            assertEquals(-78901234, subReader.getInt32Field());
+            assertEquals(56789012345678L, subReader.getInt64Field());
+            assertEquals(90, subReader.getUInt8Field());
+            assertEquals(1234, subReader.getUInt16Field());
+            assertEquals(56789012, subReader.getUInt32Field());
+            assertEquals(345678901234567890L, subReader.getUInt64Field());
+            assertEquals(-1.25e-10f, subReader.getFloat32Field(), DELTA);
+            assertEquals(345, subReader.getFloat64Field(), DELTA);
 
             {
                 org.capnproto.test.Test.TestAllTypes.Reader subSubReader = subReader.getStructField();
-                assertEquals(subSubReader.getTextField().toString(), "nested");
+                assertEquals("nested", subSubReader.getTextField().toString());
             }
             PrimitiveList.Boolean.Reader boolList = subReader.getBoolList();
-            assertEquals(boolList.get(0), false);
-            assertEquals(boolList.get(1), true);
-            assertEquals(boolList.get(2), false);
-            assertEquals(boolList.get(3), true);
-            assertEquals(boolList.get(4), true);
+            assertEquals(false, boolList.get(0));
+            assertEquals(true, boolList.get(1));
+            assertEquals(false, boolList.get(2));
+            assertEquals(true, boolList.get(3));
+            assertEquals(true, boolList.get(4));
 
         }
 
-        assertEquals(reader.getVoidList().size(), 6);
+        assertEquals(6, reader.getVoidList().size());
 
         PrimitiveList.Boolean.Reader boolList = reader.getBoolList();
-        assertEquals(boolList.get(0), true);
-        assertEquals(boolList.get(1), false);
-        assertEquals(boolList.get(2), false);
-        assertEquals(boolList.get(3), true);
+        assertEquals(true, boolList.get(0));
+        assertEquals(false, boolList.get(1));
+        assertEquals(false, boolList.get(2));
+        assertEquals(true, boolList.get(3));
 
         PrimitiveList.Double.Reader float64List = reader.getFloat64List();
-        assertEquals(float64List.get(0), 7777.75, DELTA);
-        assertEquals(float64List.get(1), Double.POSITIVE_INFINITY, DELTA);
-        assertEquals(float64List.get(2), Double.NEGATIVE_INFINITY, DELTA);
-        assertEquals(float64List.get(3), Double.NaN, DELTA);
+        assertEquals(7777.75, float64List.get(0), DELTA);
+        assertEquals(Double.POSITIVE_INFINITY, float64List.get(1), DELTA);
+        assertEquals(Double.NEGATIVE_INFINITY, float64List.get(2), DELTA);
+        assertEquals(Double.NaN, float64List.get(3), DELTA);
 
         TextList.Reader textList = reader.getTextList();
-        assertEquals(textList.size(), 3);
-        assertEquals(textList.get(0).toString(), "plugh");
-        assertEquals(textList.get(1).toString(), "xyzzy");
-        assertEquals(textList.get(2).toString(), "thud");
+        assertEquals(3, textList.size());
+        assertEquals("plugh", textList.get(0).toString());
+        assertEquals("xyzzy", textList.get(1).toString());
+        assertEquals("thud", textList.get(2).toString());
         StructList.Reader<org.capnproto.test.Test.TestAllTypes.Reader> structList = reader.getStructList();
         assertEquals(3, structList.size());
-        assertEquals(structList.get(0).getTextField().toString(), "structlist 1");
-        assertEquals(structList.get(1).getTextField().toString(), "structlist 2");
-        assertEquals(structList.get(2).getTextField().toString(), "structlist 3");
+        assertEquals("structlist 1", structList.get(0).getTextField().toString());
+        assertEquals("structlist 2", structList.get(1).getTextField().toString());
+        assertEquals("structlist 3", structList.get(2).getTextField().toString());
 
         EnumList.Reader<org.capnproto.test.Test.TestEnum> enumList = reader.getEnumList();
         assertEquals(enumList.get(0), org.capnproto.test.Test.TestEnum.FOO);
@@ -253,60 +253,60 @@ public class TestUtil {
     public static void checkDefaultMessage(org.capnproto.test.Test.TestDefaults.Builder builder) {
         builder.getVoidField();
         assertTrue(builder.getBoolField());
-        assertEquals(builder.getInt8Field(), -123);
-        assertEquals(builder.getInt16Field(), -12345);
-        assertEquals(builder.getInt32Field(), -12345678);
-        assertEquals(builder.getInt64Field(), -123456789012345L);
-        assertEquals(builder.getUInt8Field(), (byte)0xea);
-        assertEquals(builder.getUInt16Field(), (short)45678);
-        assertEquals(builder.getUInt32Field(), 0xce0a6a14);
-        assertEquals(builder.getUInt64Field(), 0xab54a98ceb1f0ad2L);
-        assertEquals(builder.getFloat32Field(), 1234.5f, DELTA);
-        assertEquals(builder.getFloat64Field(), -123e45, DELTA);
+        assertEquals(-123, builder.getInt8Field());
+        assertEquals(-12345, builder.getInt16Field());
+        assertEquals(-12345678, builder.getInt32Field());
+        assertEquals(-123456789012345L, builder.getInt64Field());
+        assertEquals((byte)0xea, builder.getUInt8Field());
+        assertEquals((short)45678, builder.getUInt16Field());
+        assertEquals(0xce0a6a14, builder.getUInt32Field());
+        assertEquals(0xab54a98ceb1f0ad2L, builder.getUInt64Field());
+        assertEquals(1234.5f, builder.getFloat32Field(), DELTA);
+        assertEquals(-123e45, builder.getFloat64Field(), DELTA);
         assertEquals(builder.getEnumField(), org.capnproto.test.Test.TestEnum.CORGE);
 
-        assertEquals(builder.getTextField().toString(), "foo");
-        assertArrayEquals(builder.getDataField().toArray(), new byte[]{0x62, 0x61, 0x72});
+        assertEquals("foo", builder.getTextField().toString());
+        assertArrayEquals(new byte[]{0x62, 0x61, 0x72}, builder.getDataField().toArray());
     }
 
     public static void checkDefaultMessage(org.capnproto.test.Test.TestDefaults.Reader reader) {
         reader.getVoidField();
-        assertEquals(reader.getBoolField(), true);
-        assertEquals(reader.getInt8Field(), -123);
-        assertEquals(reader.getInt16Field(), -12345);
-        assertEquals(reader.getInt32Field(), -12345678);
-        assertEquals(reader.getInt64Field(), -123456789012345L);
-        assertEquals(reader.getUInt8Field(), (byte)0xea);
-        assertEquals(reader.getUInt16Field(), (short)45678);
-        assertEquals(reader.getUInt32Field(), 0xce0a6a14);
-        assertEquals(reader.getUInt64Field(), 0xab54a98ceb1f0ad2L);
-        assertEquals(reader.getFloat32Field(), 1234.5f, DELTA);
-        assertEquals(reader.getFloat64Field(), -123e45, DELTA);
-        assertEquals(reader.getTextField().toString(), "foo");
-        assertArrayEquals(reader.getDataField().toArray(), new byte[]{0x62, 0x61, 0x72});
+        assertEquals(true, reader.getBoolField());
+        assertEquals(-123, reader.getInt8Field());
+        assertEquals(-12345, reader.getInt16Field());
+        assertEquals(-12345678, reader.getInt32Field());
+        assertEquals(-123456789012345L, reader.getInt64Field());
+        assertEquals((byte)0xea, reader.getUInt8Field());
+        assertEquals((short)45678, reader.getUInt16Field());
+        assertEquals(0xce0a6a14, reader.getUInt32Field());
+        assertEquals(0xab54a98ceb1f0ad2L, reader.getUInt64Field());
+        assertEquals(1234.5f, reader.getFloat32Field(), DELTA);
+        assertEquals(-123e45, reader.getFloat64Field(), DELTA);
+        assertEquals("foo", reader.getTextField().toString());
+        assertArrayEquals(new byte[]{0x62, 0x61, 0x72}, reader.getDataField().toArray());
         {
             org.capnproto.test.Test.TestAllTypes.Reader subReader = reader.getStructField();
             subReader.getVoidField();
             assertTrue(subReader.getBoolField());
-            assertEquals(subReader.getInt8Field(), -12);
-            assertEquals(subReader.getInt16Field(), 3456);
-            assertEquals(subReader.getInt32Field(), -78901234);
+            assertEquals(-12, subReader.getInt8Field());
+            assertEquals(3456, subReader.getInt16Field());
+            assertEquals(-78901234, subReader.getInt32Field());
             // ...
-            assertEquals(subReader.getTextField().toString(), "baz");
+            assertEquals("baz", subReader.getTextField().toString());
 
             {
                 org.capnproto.test.Test.TestAllTypes.Reader subSubReader = subReader.getStructField();
-                assertEquals(subSubReader.getTextField().toString(), "nested");
+                assertEquals("nested", subSubReader.getTextField().toString());
             }
 
         }
 
         assertEquals(reader.getEnumField(), org.capnproto.test.Test.TestEnum.CORGE);
-        assertEquals(reader.getVoidList().size(), 6);
+        assertEquals(6, reader.getVoidList().size());
 
         {
             PrimitiveList.Boolean.Reader listReader = reader.getBoolList();
-            assertEquals(listReader.size(), 4);
+            assertEquals(4, listReader.size());
             assertTrue(listReader.get(0));
             assertFalse(listReader.get(1));
             assertFalse(listReader.get(2));
@@ -315,9 +315,9 @@ public class TestUtil {
 
         {
             PrimitiveList.Byte.Reader listReader = reader.getInt8List();
-            assertEquals(listReader.size(), 2);
-            assertEquals(listReader.get(0), 111);
-            assertEquals(listReader.get(1), -111);
+            assertEquals(2, listReader.size());
+            assertEquals(111, listReader.get(0));
+            assertEquals(-111, listReader.get(1));
         }
     }
 
@@ -338,17 +338,17 @@ public class TestUtil {
     }
 
     public static void checkSettedDefaultMessage(org.capnproto.test.Test.TestDefaults.Reader reader) {
-        assertEquals(reader.getBoolField(), false);
-        assertEquals(reader.getInt8Field(), -122);
-        assertEquals(reader.getInt16Field(), -12344);
-        assertEquals(reader.getInt32Field(), -12345677);
-        assertEquals(reader.getInt64Field(), -123456789012344L);
-        assertEquals(reader.getUInt8Field(), (byte) 0xe9);
-        assertEquals(reader.getUInt16Field(), (short) 45677);
-        assertEquals(reader.getUInt32Field(), 0xce0a6a13);
-        assertEquals(reader.getUInt64Field(), 0xab54a98ceb1f0ad1L);
-        assertEquals(reader.getFloat32Field(), 1234.4f, DELTA);
-        assertEquals(reader.getFloat64Field(), -123e44, DELTA);
+        assertEquals(false, reader.getBoolField());
+        assertEquals(-122, reader.getInt8Field());
+        assertEquals(-12344, reader.getInt16Field());
+        assertEquals(-12345677, reader.getInt32Field());
+        assertEquals(-123456789012344L, reader.getInt64Field());
+        assertEquals((byte) 0xe9, reader.getUInt8Field());
+        assertEquals((short) 45677, reader.getUInt16Field());
+        assertEquals(0xce0a6a13, reader.getUInt32Field());
+        assertEquals(0xab54a98ceb1f0ad1L, reader.getUInt64Field());
+        assertEquals(1234.4f, reader.getFloat32Field(), DELTA);
+        assertEquals(-123e44, reader.getFloat64Field(), DELTA);
         assertEquals(reader.getEnumField(), org.capnproto.test.Test.TestEnum.QUX);
     }
 }

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -36,9 +36,9 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/runtime/src/test/java/org/capnproto/ArrayInputStreamTest.java
+++ b/runtime/src/test/java/org/capnproto/ArrayInputStreamTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class ArrayInputStreamTest {
   @Test
   public void testEmptyArray() throws java.io.IOException {
@@ -34,7 +36,7 @@ public class ArrayInputStreamTest {
 
     // read() should return -1 at the end of the stream
     // https://docs.oracle.com/javase/7/docs/api/java/nio/channels/ReadableByteChannel.html
-    Assertions.assertEquals(stream.read(dst), -1);
+    assertEquals(stream.read(dst), -1);
   }
 
   @Test
@@ -42,7 +44,7 @@ public class ArrayInputStreamTest {
     byte[] oneByte = new byte[]{42};
     ArrayInputStream stream = new ArrayInputStream(ByteBuffer.wrap(oneByte));
     ByteBuffer dst = ByteBuffer.allocate(10);
-    Assertions.assertEquals(stream.read(dst), 1);
-    Assertions.assertEquals(stream.read(dst), -1); // end of stream
+    assertEquals(stream.read(dst), 1);
+    assertEquals(stream.read(dst), -1); // end of stream
   }
 }

--- a/runtime/src/test/java/org/capnproto/ArrayInputStreamTest.java
+++ b/runtime/src/test/java/org/capnproto/ArrayInputStreamTest.java
@@ -36,7 +36,7 @@ public class ArrayInputStreamTest {
 
     // read() should return -1 at the end of the stream
     // https://docs.oracle.com/javase/7/docs/api/java/nio/channels/ReadableByteChannel.html
-    assertEquals(stream.read(dst), -1);
+    assertEquals(-1, stream.read(dst));
   }
 
   @Test
@@ -44,7 +44,7 @@ public class ArrayInputStreamTest {
     byte[] oneByte = new byte[]{42};
     ArrayInputStream stream = new ArrayInputStream(ByteBuffer.wrap(oneByte));
     ByteBuffer dst = ByteBuffer.allocate(10);
-    assertEquals(stream.read(dst), 1);
-    assertEquals(stream.read(dst), -1); // end of stream
+    assertEquals(1, stream.read(dst));
+    assertEquals(-1, stream.read(dst)); // end of stream
   }
 }

--- a/runtime/src/test/java/org/capnproto/ArrayInputStreamTest.java
+++ b/runtime/src/test/java/org/capnproto/ArrayInputStreamTest.java
@@ -21,8 +21,8 @@
 
 package org.capnproto;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
@@ -34,7 +34,7 @@ public class ArrayInputStreamTest {
 
     // read() should return -1 at the end of the stream
     // https://docs.oracle.com/javase/7/docs/api/java/nio/channels/ReadableByteChannel.html
-    Assert.assertEquals(stream.read(dst), -1);
+    Assertions.assertEquals(stream.read(dst), -1);
   }
 
   @Test
@@ -42,7 +42,7 @@ public class ArrayInputStreamTest {
     byte[] oneByte = new byte[]{42};
     ArrayInputStream stream = new ArrayInputStream(ByteBuffer.wrap(oneByte));
     ByteBuffer dst = ByteBuffer.allocate(10);
-    Assert.assertEquals(stream.read(dst), 1);
-    Assert.assertEquals(stream.read(dst), -1); // end of stream
+    Assertions.assertEquals(stream.read(dst), 1);
+    Assertions.assertEquals(stream.read(dst), -1); // end of stream
   }
 }

--- a/runtime/src/test/java/org/capnproto/DefaultAllocatorTest.java
+++ b/runtime/src/test/java/org/capnproto/DefaultAllocatorTest.java
@@ -9,8 +9,7 @@ public class DefaultAllocatorTest {
     @Test
     public void maxSegmentBytes() {
       DefaultAllocator allocator = new DefaultAllocator();
-      assertEquals(allocator.allocationStrategy,
-                          BuilderArena.AllocationStrategy.GROW_HEURISTICALLY);
+      assertEquals(BuilderArena.AllocationStrategy.GROW_HEURISTICALLY, allocator.allocationStrategy);
       allocator.maxSegmentBytes = (1 << 25) - 1;
 
       int allocationSize = 1 << 24;

--- a/runtime/src/test/java/org/capnproto/DefaultAllocatorTest.java
+++ b/runtime/src/test/java/org/capnproto/DefaultAllocatorTest.java
@@ -1,26 +1,26 @@
 package org.capnproto;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DefaultAllocatorTest {
     @Test
     public void maxSegmentBytes() {
       DefaultAllocator allocator = new DefaultAllocator();
-      Assert.assertEquals(allocator.allocationStrategy,
+      Assertions.assertEquals(allocator.allocationStrategy,
                           BuilderArena.AllocationStrategy.GROW_HEURISTICALLY);
       allocator.maxSegmentBytes = (1 << 25) - 1;
 
       int allocationSize = 1 << 24;
       allocator.setNextAllocationSizeBytes(allocationSize);
 
-      Assert.assertEquals(allocationSize,
+      Assertions.assertEquals(allocationSize,
                           allocator.allocateSegment(allocationSize).capacity());
 
-      Assert.assertEquals(allocator.maxSegmentBytes,
+      Assertions.assertEquals(allocator.maxSegmentBytes,
                           allocator.allocateSegment(allocationSize).capacity());
 
-      Assert.assertEquals(allocator.maxSegmentBytes,
+      Assertions.assertEquals(allocator.maxSegmentBytes,
                           allocator.allocateSegment(allocationSize).capacity());
     }
 }

--- a/runtime/src/test/java/org/capnproto/DefaultAllocatorTest.java
+++ b/runtime/src/test/java/org/capnproto/DefaultAllocatorTest.java
@@ -3,24 +3,26 @@ package org.capnproto;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class DefaultAllocatorTest {
     @Test
     public void maxSegmentBytes() {
       DefaultAllocator allocator = new DefaultAllocator();
-      Assertions.assertEquals(allocator.allocationStrategy,
+      assertEquals(allocator.allocationStrategy,
                           BuilderArena.AllocationStrategy.GROW_HEURISTICALLY);
       allocator.maxSegmentBytes = (1 << 25) - 1;
 
       int allocationSize = 1 << 24;
       allocator.setNextAllocationSizeBytes(allocationSize);
 
-      Assertions.assertEquals(allocationSize,
+      assertEquals(allocationSize,
                           allocator.allocateSegment(allocationSize).capacity());
 
-      Assertions.assertEquals(allocator.maxSegmentBytes,
+      assertEquals(allocator.maxSegmentBytes,
                           allocator.allocateSegment(allocationSize).capacity());
 
-      Assertions.assertEquals(allocator.maxSegmentBytes,
+      assertEquals(allocator.maxSegmentBytes,
                           allocator.allocateSegment(allocationSize).capacity());
     }
 }

--- a/runtime/src/test/java/org/capnproto/LayoutTest.java
+++ b/runtime/src/test/java/org/capnproto/LayoutTest.java
@@ -6,6 +6,9 @@ import org.junit.jupiter.api.Test;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class LayoutTest {
 
     private static final int MAX_NESTING_LIMIT = 0x7fffffff;
@@ -30,40 +33,40 @@ public class LayoutTest {
 
         StructReader reader = WireHelpers.readStructPointer(new BareStructReader(), arena.tryGetSegment(0), 0, null, 0, MAX_NESTING_LIMIT);
 
-        Assertions.assertEquals(reader._getLongField(0), 0xefcdab8967452301L);
-        Assertions.assertEquals(reader._getLongField(1), 0L);
+        assertEquals(reader._getLongField(0), 0xefcdab8967452301L);
+        assertEquals(reader._getLongField(1), 0L);
 
-        Assertions.assertEquals(reader._getIntField(0), 0x67452301);
-        Assertions.assertEquals(reader._getIntField(1), 0xefcdab89);
-        Assertions.assertEquals(reader._getIntField(2), 0);
+        assertEquals(reader._getIntField(0), 0x67452301);
+        assertEquals(reader._getIntField(1), 0xefcdab89);
+        assertEquals(reader._getIntField(2), 0);
 
-        Assertions.assertEquals(reader._getShortField(0), (short)0x2301);
-        Assertions.assertEquals(reader._getShortField(1), (short)0x6745);
-        Assertions.assertEquals(reader._getShortField(2), (short)0xab89);
-        Assertions.assertEquals(reader._getShortField(3), (short)0xefcd);
-        Assertions.assertEquals(reader._getShortField(4), (short)0);
+        assertEquals(reader._getShortField(0), (short)0x2301);
+        assertEquals(reader._getShortField(1), (short)0x6745);
+        assertEquals(reader._getShortField(2), (short)0xab89);
+        assertEquals(reader._getShortField(3), (short)0xefcd);
+        assertEquals(reader._getShortField(4), (short)0);
 
-        Assertions.assertEquals(reader._getBooleanField(0), true);
-        Assertions.assertEquals(reader._getBooleanField(1), false);
-        Assertions.assertEquals(reader._getBooleanField(2), false);
+        assertEquals(reader._getBooleanField(0), true);
+        assertEquals(reader._getBooleanField(1), false);
+        assertEquals(reader._getBooleanField(2), false);
 
-        Assertions.assertEquals(reader._getBooleanField(3), false);
-        Assertions.assertEquals(reader._getBooleanField(4), false);
-        Assertions.assertEquals(reader._getBooleanField(5), false);
-        Assertions.assertEquals(reader._getBooleanField(6), false);
-        Assertions.assertEquals(reader._getBooleanField(7), false);
+        assertEquals(reader._getBooleanField(3), false);
+        assertEquals(reader._getBooleanField(4), false);
+        assertEquals(reader._getBooleanField(5), false);
+        assertEquals(reader._getBooleanField(6), false);
+        assertEquals(reader._getBooleanField(7), false);
 
-        Assertions.assertEquals(reader._getBooleanField(8), true);
-        Assertions.assertEquals(reader._getBooleanField(9), true);
-        Assertions.assertEquals(reader._getBooleanField(10), false);
-        Assertions.assertEquals(reader._getBooleanField(11), false);
-        Assertions.assertEquals(reader._getBooleanField(12), false);
-        Assertions.assertEquals(reader._getBooleanField(13), true);
-        Assertions.assertEquals(reader._getBooleanField(14), false);
-        Assertions.assertEquals(reader._getBooleanField(15), false);
+        assertEquals(reader._getBooleanField(8), true);
+        assertEquals(reader._getBooleanField(9), true);
+        assertEquals(reader._getBooleanField(10), false);
+        assertEquals(reader._getBooleanField(11), false);
+        assertEquals(reader._getBooleanField(12), false);
+        assertEquals(reader._getBooleanField(13), true);
+        assertEquals(reader._getBooleanField(14), false);
+        assertEquals(reader._getBooleanField(15), false);
 
-        Assertions.assertEquals(reader._getBooleanField(63), true);
-        Assertions.assertEquals(reader._getBooleanField(64), false);
+        assertEquals(reader._getBooleanField(63), true);
+        assertEquals(reader._getBooleanField(64), false);
     }
 
     /**
@@ -86,7 +89,7 @@ public class LayoutTest {
 
         ReaderArena arena = new ReaderArena(new ByteBuffer[]{ buffer }, 0x7fffffffffffffffL);
 
-        Assertions.assertThrows(DecodeException.class, () -> WireHelpers.readStructPointer(new BareStructReader(), arena.tryGetSegment(0), 0, null, 0, MAX_NESTING_LIMIT));
+        assertThrows(DecodeException.class, () -> WireHelpers.readStructPointer(new BareStructReader(), arena.tryGetSegment(0), 0, null, 0, MAX_NESTING_LIMIT));
     }
 
 
@@ -114,7 +117,7 @@ public class LayoutTest {
 
         ReaderArena arena = new ReaderArena(new ByteBuffer[]{buffer}, 0x7fffffffffffffffL);
 
-        Assertions.assertThrows(DecodeException.class, () -> WireHelpers.readListPointer(new BareListReader(), arena.tryGetSegment(0), 0, null, 0, (byte) 0, MAX_NESTING_LIMIT));
+        assertThrows(DecodeException.class, () -> WireHelpers.readListPointer(new BareListReader(), arena.tryGetSegment(0), 0, null, 0, (byte) 0, MAX_NESTING_LIMIT));
     }
 
     private class BareStructBuilder implements StructBuilder.Factory<StructBuilder> {
@@ -165,17 +168,17 @@ public class LayoutTest {
     }
 
     private void checkStruct(StructBuilder builder) {
-        Assertions.assertEquals(0x1011121314151617L, builder._getLongField(0));
-        Assertions.assertEquals(0x20212223, builder._getIntField(2));
-        Assertions.assertEquals(0x3031, builder._getShortField(6));
-        Assertions.assertEquals(0x40, builder._getByteField(14));
-        Assertions.assertEquals(false, builder._getBooleanField(120));
-        Assertions.assertEquals(false, builder._getBooleanField(121));
-        Assertions.assertEquals(true, builder._getBooleanField(122));
-        Assertions.assertEquals(false, builder._getBooleanField(123));
-        Assertions.assertEquals(true, builder._getBooleanField(124));
-        Assertions.assertEquals(true, builder._getBooleanField(125));
-        Assertions.assertEquals(true, builder._getBooleanField(126));
-        Assertions.assertEquals(false, builder._getBooleanField(127));
+        assertEquals(0x1011121314151617L, builder._getLongField(0));
+        assertEquals(0x20212223, builder._getIntField(2));
+        assertEquals(0x3031, builder._getShortField(6));
+        assertEquals(0x40, builder._getByteField(14));
+        assertEquals(false, builder._getBooleanField(120));
+        assertEquals(false, builder._getBooleanField(121));
+        assertEquals(true, builder._getBooleanField(122));
+        assertEquals(false, builder._getBooleanField(123));
+        assertEquals(true, builder._getBooleanField(124));
+        assertEquals(true, builder._getBooleanField(125));
+        assertEquals(true, builder._getBooleanField(126));
+        assertEquals(false, builder._getBooleanField(127));
     }
 }

--- a/runtime/src/test/java/org/capnproto/LayoutTest.java
+++ b/runtime/src/test/java/org/capnproto/LayoutTest.java
@@ -33,40 +33,40 @@ public class LayoutTest {
 
         StructReader reader = WireHelpers.readStructPointer(new BareStructReader(), arena.tryGetSegment(0), 0, null, 0, MAX_NESTING_LIMIT);
 
-        assertEquals(reader._getLongField(0), 0xefcdab8967452301L);
-        assertEquals(reader._getLongField(1), 0L);
+        assertEquals(0xefcdab8967452301L, reader._getLongField(0));
+        assertEquals(0L, reader._getLongField(1));
 
-        assertEquals(reader._getIntField(0), 0x67452301);
-        assertEquals(reader._getIntField(1), 0xefcdab89);
-        assertEquals(reader._getIntField(2), 0);
+        assertEquals(0x67452301, reader._getIntField(0));
+        assertEquals(0xefcdab89, reader._getIntField(1));
+        assertEquals(0, reader._getIntField(2));
 
-        assertEquals(reader._getShortField(0), (short)0x2301);
-        assertEquals(reader._getShortField(1), (short)0x6745);
-        assertEquals(reader._getShortField(2), (short)0xab89);
-        assertEquals(reader._getShortField(3), (short)0xefcd);
-        assertEquals(reader._getShortField(4), (short)0);
+        assertEquals((short)0x2301, reader._getShortField(0));
+        assertEquals((short)0x6745, reader._getShortField(1));
+        assertEquals((short)0xab89, reader._getShortField(2));
+        assertEquals((short)0xefcd, reader._getShortField(3));
+        assertEquals((short)0, reader._getShortField(4));
 
-        assertEquals(reader._getBooleanField(0), true);
-        assertEquals(reader._getBooleanField(1), false);
-        assertEquals(reader._getBooleanField(2), false);
+        assertEquals(true, reader._getBooleanField(0));
+        assertEquals(false, reader._getBooleanField(1));
+        assertEquals(false, reader._getBooleanField(2));
 
-        assertEquals(reader._getBooleanField(3), false);
-        assertEquals(reader._getBooleanField(4), false);
-        assertEquals(reader._getBooleanField(5), false);
-        assertEquals(reader._getBooleanField(6), false);
-        assertEquals(reader._getBooleanField(7), false);
+        assertEquals(false, reader._getBooleanField(3));
+        assertEquals(false, reader._getBooleanField(4));
+        assertEquals(false, reader._getBooleanField(5));
+        assertEquals(false, reader._getBooleanField(6));
+        assertEquals(false, reader._getBooleanField(7));
 
-        assertEquals(reader._getBooleanField(8), true);
-        assertEquals(reader._getBooleanField(9), true);
-        assertEquals(reader._getBooleanField(10), false);
-        assertEquals(reader._getBooleanField(11), false);
-        assertEquals(reader._getBooleanField(12), false);
-        assertEquals(reader._getBooleanField(13), true);
-        assertEquals(reader._getBooleanField(14), false);
-        assertEquals(reader._getBooleanField(15), false);
+        assertEquals(true, reader._getBooleanField(8));
+        assertEquals(true, reader._getBooleanField(9));
+        assertEquals(false, reader._getBooleanField(10));
+        assertEquals(false, reader._getBooleanField(11));
+        assertEquals(false, reader._getBooleanField(12));
+        assertEquals(true, reader._getBooleanField(13));
+        assertEquals(false, reader._getBooleanField(14));
+        assertEquals(false, reader._getBooleanField(15));
 
-        assertEquals(reader._getBooleanField(63), true);
-        assertEquals(reader._getBooleanField(64), false);
+        assertEquals(true, reader._getBooleanField(63));
+        assertEquals(false, reader._getBooleanField(64));
     }
 
     /**

--- a/runtime/src/test/java/org/capnproto/LayoutTest.java
+++ b/runtime/src/test/java/org/capnproto/LayoutTest.java
@@ -1,7 +1,7 @@
 package org.capnproto;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -30,46 +30,46 @@ public class LayoutTest {
 
         StructReader reader = WireHelpers.readStructPointer(new BareStructReader(), arena.tryGetSegment(0), 0, null, 0, MAX_NESTING_LIMIT);
 
-        Assert.assertEquals(reader._getLongField(0), 0xefcdab8967452301L);
-        Assert.assertEquals(reader._getLongField(1), 0L);
+        Assertions.assertEquals(reader._getLongField(0), 0xefcdab8967452301L);
+        Assertions.assertEquals(reader._getLongField(1), 0L);
 
-        Assert.assertEquals(reader._getIntField(0), 0x67452301);
-        Assert.assertEquals(reader._getIntField(1), 0xefcdab89);
-        Assert.assertEquals(reader._getIntField(2), 0);
+        Assertions.assertEquals(reader._getIntField(0), 0x67452301);
+        Assertions.assertEquals(reader._getIntField(1), 0xefcdab89);
+        Assertions.assertEquals(reader._getIntField(2), 0);
 
-        Assert.assertEquals(reader._getShortField(0), (short)0x2301);
-        Assert.assertEquals(reader._getShortField(1), (short)0x6745);
-        Assert.assertEquals(reader._getShortField(2), (short)0xab89);
-        Assert.assertEquals(reader._getShortField(3), (short)0xefcd);
-        Assert.assertEquals(reader._getShortField(4), (short)0);
+        Assertions.assertEquals(reader._getShortField(0), (short)0x2301);
+        Assertions.assertEquals(reader._getShortField(1), (short)0x6745);
+        Assertions.assertEquals(reader._getShortField(2), (short)0xab89);
+        Assertions.assertEquals(reader._getShortField(3), (short)0xefcd);
+        Assertions.assertEquals(reader._getShortField(4), (short)0);
 
-        Assert.assertEquals(reader._getBooleanField(0), true);
-        Assert.assertEquals(reader._getBooleanField(1), false);
-        Assert.assertEquals(reader._getBooleanField(2), false);
+        Assertions.assertEquals(reader._getBooleanField(0), true);
+        Assertions.assertEquals(reader._getBooleanField(1), false);
+        Assertions.assertEquals(reader._getBooleanField(2), false);
 
-        Assert.assertEquals(reader._getBooleanField(3), false);
-        Assert.assertEquals(reader._getBooleanField(4), false);
-        Assert.assertEquals(reader._getBooleanField(5), false);
-        Assert.assertEquals(reader._getBooleanField(6), false);
-        Assert.assertEquals(reader._getBooleanField(7), false);
+        Assertions.assertEquals(reader._getBooleanField(3), false);
+        Assertions.assertEquals(reader._getBooleanField(4), false);
+        Assertions.assertEquals(reader._getBooleanField(5), false);
+        Assertions.assertEquals(reader._getBooleanField(6), false);
+        Assertions.assertEquals(reader._getBooleanField(7), false);
 
-        Assert.assertEquals(reader._getBooleanField(8), true);
-        Assert.assertEquals(reader._getBooleanField(9), true);
-        Assert.assertEquals(reader._getBooleanField(10), false);
-        Assert.assertEquals(reader._getBooleanField(11), false);
-        Assert.assertEquals(reader._getBooleanField(12), false);
-        Assert.assertEquals(reader._getBooleanField(13), true);
-        Assert.assertEquals(reader._getBooleanField(14), false);
-        Assert.assertEquals(reader._getBooleanField(15), false);
+        Assertions.assertEquals(reader._getBooleanField(8), true);
+        Assertions.assertEquals(reader._getBooleanField(9), true);
+        Assertions.assertEquals(reader._getBooleanField(10), false);
+        Assertions.assertEquals(reader._getBooleanField(11), false);
+        Assertions.assertEquals(reader._getBooleanField(12), false);
+        Assertions.assertEquals(reader._getBooleanField(13), true);
+        Assertions.assertEquals(reader._getBooleanField(14), false);
+        Assertions.assertEquals(reader._getBooleanField(15), false);
 
-        Assert.assertEquals(reader._getBooleanField(63), true);
-        Assert.assertEquals(reader._getBooleanField(64), false);
+        Assertions.assertEquals(reader._getBooleanField(63), true);
+        Assertions.assertEquals(reader._getBooleanField(64), false);
     }
 
     /**
      * @see <a href="https://github.com/capnproto/capnproto-java/issues/122">#122</a>
      */
-    @Test(expected = DecodeException.class)
+    @Test
     public void readStructPointerShouldThrowDecodeExceptionOnOutOfBoundsStructPointer() {
         byte[] brokenMSG = new byte[]{
                 0x00, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, //declare word size of 7, with payload of only 6 words
@@ -86,7 +86,7 @@ public class LayoutTest {
 
         ReaderArena arena = new ReaderArena(new ByteBuffer[]{ buffer }, 0x7fffffffffffffffL);
 
-        StructReader reader = WireHelpers.readStructPointer(new BareStructReader(), arena.tryGetSegment(0), 0, null, 0, MAX_NESTING_LIMIT);
+        Assertions.assertThrows(DecodeException.class, () -> WireHelpers.readStructPointer(new BareStructReader(), arena.tryGetSegment(0), 0, null, 0, MAX_NESTING_LIMIT));
     }
 
 
@@ -100,7 +100,7 @@ public class LayoutTest {
         }
     }
 
-    @Test(expected = DecodeException.class)
+    @Test
     public void readListPointerShouldThrowDecodeExceptionOnOutOfBoundsCompositeListPointer() {
         byte[] brokenMSG = {
                 // set list pointer bits to 1, elementSize to 7 to indicate composite list and number of words in the list (minus tag) to 0x1FFFFFFF (max value possible in 29b limit)
@@ -114,7 +114,7 @@ public class LayoutTest {
 
         ReaderArena arena = new ReaderArena(new ByteBuffer[]{buffer}, 0x7fffffffffffffffL);
 
-        ListReader reader = WireHelpers.readListPointer(new BareListReader(), arena.tryGetSegment(0), 0, null, 0, (byte) 0, MAX_NESTING_LIMIT);
+        Assertions.assertThrows(DecodeException.class, () -> WireHelpers.readListPointer(new BareListReader(), arena.tryGetSegment(0), 0, null, 0, (byte) 0, MAX_NESTING_LIMIT));
     }
 
     private class BareStructBuilder implements StructBuilder.Factory<StructBuilder> {
@@ -165,17 +165,17 @@ public class LayoutTest {
     }
 
     private void checkStruct(StructBuilder builder) {
-        Assert.assertEquals(0x1011121314151617L, builder._getLongField(0));
-        Assert.assertEquals(0x20212223, builder._getIntField(2));
-        Assert.assertEquals(0x3031, builder._getShortField(6));
-        Assert.assertEquals(0x40, builder._getByteField(14));
-        Assert.assertEquals(false, builder._getBooleanField(120));
-        Assert.assertEquals(false, builder._getBooleanField(121));
-        Assert.assertEquals(true, builder._getBooleanField(122));
-        Assert.assertEquals(false, builder._getBooleanField(123));
-        Assert.assertEquals(true, builder._getBooleanField(124));
-        Assert.assertEquals(true, builder._getBooleanField(125));
-        Assert.assertEquals(true, builder._getBooleanField(126));
-        Assert.assertEquals(false, builder._getBooleanField(127));
+        Assertions.assertEquals(0x1011121314151617L, builder._getLongField(0));
+        Assertions.assertEquals(0x20212223, builder._getIntField(2));
+        Assertions.assertEquals(0x3031, builder._getShortField(6));
+        Assertions.assertEquals(0x40, builder._getByteField(14));
+        Assertions.assertEquals(false, builder._getBooleanField(120));
+        Assertions.assertEquals(false, builder._getBooleanField(121));
+        Assertions.assertEquals(true, builder._getBooleanField(122));
+        Assertions.assertEquals(false, builder._getBooleanField(123));
+        Assertions.assertEquals(true, builder._getBooleanField(124));
+        Assertions.assertEquals(true, builder._getBooleanField(125));
+        Assertions.assertEquals(true, builder._getBooleanField(126));
+        Assertions.assertEquals(false, builder._getBooleanField(127));
     }
 }

--- a/runtime/src/test/java/org/capnproto/ListBuilderTest.java
+++ b/runtime/src/test/java/org/capnproto/ListBuilderTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class ListBuilderTest {
 
     @Test
@@ -14,6 +16,6 @@ public class ListBuilderTest {
         SegmentBuilder segmentBuilder = new SegmentBuilder(buffer, builderArena);
         ListBuilder listBuilder = new ListBuilder(segmentBuilder, 0, 0, 2, 0, (short) 0);
 
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> listBuilder._setBooleanElement(Integer.MAX_VALUE, true));
+        assertThrows(IndexOutOfBoundsException.class, () -> listBuilder._setBooleanElement(Integer.MAX_VALUE, true));
     }
 }

--- a/runtime/src/test/java/org/capnproto/ListBuilderTest.java
+++ b/runtime/src/test/java/org/capnproto/ListBuilderTest.java
@@ -1,18 +1,19 @@
 package org.capnproto;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
 public class ListBuilderTest {
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void _setBooleanElementShouldNotOverflowDuringPositionOffsetCalculation() {
         ByteBuffer buffer = ByteBuffer.allocate(10);
         BuilderArena builderArena = new BuilderArena(new DefaultAllocator());
         SegmentBuilder segmentBuilder = new SegmentBuilder(buffer, builderArena);
         ListBuilder listBuilder = new ListBuilder(segmentBuilder, 0, 0, 2, 0, (short) 0);
 
-        listBuilder._setBooleanElement(Integer.MAX_VALUE, true);
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> listBuilder._setBooleanElement(Integer.MAX_VALUE, true));
     }
 }

--- a/runtime/src/test/java/org/capnproto/SegmentReaderTest.java
+++ b/runtime/src/test/java/org/capnproto/SegmentReaderTest.java
@@ -1,13 +1,11 @@
 package org.capnproto;
 
 import org.capnproto.WireHelpers.FollowFarsResult;
-import org.hamcrest.MatcherAssert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-
-import static org.hamcrest.CoreMatchers.is;
 
 public class SegmentReaderTest {
 
@@ -15,21 +13,21 @@ public class SegmentReaderTest {
     public void in_boundsCalculationShouldNotOverflow() {
         ByteBuffer byteBuffer = ByteBuffer.allocate(64);
         SegmentReader segmentReader = new SegmentReader(byteBuffer, null);
-        MatcherAssert.assertThat(segmentReader.isInBounds(0, Integer.MAX_VALUE), is(false));
+        Assertions.assertEquals(segmentReader.isInBounds(0, Integer.MAX_VALUE), false);
     }
 
     @Test
     public void oneWordAtLastWordShouldBeInBounds() {
         ByteBuffer byteBuffer = ByteBuffer.allocate(64);
         SegmentReader segmentReader = new SegmentReader(byteBuffer, null);
-        MatcherAssert.assertThat(segmentReader.isInBounds(7, 1), is(true));
+        Assertions.assertEquals(segmentReader.isInBounds(7, 1), true);
     }
 
     @Test
     public void twoWordsAtLastWordShouldNotBeInBounds() {
         ByteBuffer byteBuffer = ByteBuffer.allocate(64);
         SegmentReader segmentReader = new SegmentReader(byteBuffer, null);
-        MatcherAssert.assertThat(segmentReader.isInBounds(7, 2), is(false));
+        Assertions.assertEquals(segmentReader.isInBounds(7, 2), false);
     }
 
     @Test
@@ -78,7 +76,7 @@ public class SegmentReaderTest {
         refTarget = WirePointer.target(refOffset, ref);
         dataSizeWords = StructPointer.dataSize(ref);
         wordSize = dataSizeWords + StructPointer.ptrCount(ref);
-        MatcherAssert.assertThat(segment.isInBounds(refTarget, wordSize), is(true));
+        Assertions.assertEquals(segment.isInBounds(refTarget, wordSize), true);
 
         /* Read inner Struct: ComObject. */
         refOffset = refTarget + dataSizeWords; /* At the inner STRUCT POINTER */
@@ -86,7 +84,7 @@ public class SegmentReaderTest {
         refTarget = WirePointer.target(refOffset, ref);
         dataSizeWords = StructPointer.dataSize(ref);
         wordSize = dataSizeWords + StructPointer.ptrCount(ref);
-        MatcherAssert.assertThat(segment.isInBounds(refTarget, wordSize), is(true));
+        Assertions.assertEquals(segment.isInBounds(refTarget, wordSize), true);
     }
 
 }

--- a/runtime/src/test/java/org/capnproto/SegmentReaderTest.java
+++ b/runtime/src/test/java/org/capnproto/SegmentReaderTest.java
@@ -7,27 +7,29 @@ import org.junit.jupiter.api.Test;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class SegmentReaderTest {
 
     @Test
     public void in_boundsCalculationShouldNotOverflow() {
         ByteBuffer byteBuffer = ByteBuffer.allocate(64);
         SegmentReader segmentReader = new SegmentReader(byteBuffer, null);
-        Assertions.assertEquals(segmentReader.isInBounds(0, Integer.MAX_VALUE), false);
+        assertEquals(segmentReader.isInBounds(0, Integer.MAX_VALUE), false);
     }
 
     @Test
     public void oneWordAtLastWordShouldBeInBounds() {
         ByteBuffer byteBuffer = ByteBuffer.allocate(64);
         SegmentReader segmentReader = new SegmentReader(byteBuffer, null);
-        Assertions.assertEquals(segmentReader.isInBounds(7, 1), true);
+        assertEquals(segmentReader.isInBounds(7, 1), true);
     }
 
     @Test
     public void twoWordsAtLastWordShouldNotBeInBounds() {
         ByteBuffer byteBuffer = ByteBuffer.allocate(64);
         SegmentReader segmentReader = new SegmentReader(byteBuffer, null);
-        Assertions.assertEquals(segmentReader.isInBounds(7, 2), false);
+        assertEquals(segmentReader.isInBounds(7, 2), false);
     }
 
     @Test
@@ -76,7 +78,7 @@ public class SegmentReaderTest {
         refTarget = WirePointer.target(refOffset, ref);
         dataSizeWords = StructPointer.dataSize(ref);
         wordSize = dataSizeWords + StructPointer.ptrCount(ref);
-        Assertions.assertEquals(segment.isInBounds(refTarget, wordSize), true);
+        assertEquals(segment.isInBounds(refTarget, wordSize), true);
 
         /* Read inner Struct: ComObject. */
         refOffset = refTarget + dataSizeWords; /* At the inner STRUCT POINTER */
@@ -84,7 +86,7 @@ public class SegmentReaderTest {
         refTarget = WirePointer.target(refOffset, ref);
         dataSizeWords = StructPointer.dataSize(ref);
         wordSize = dataSizeWords + StructPointer.ptrCount(ref);
-        Assertions.assertEquals(segment.isInBounds(refTarget, wordSize), true);
+        assertEquals(segment.isInBounds(refTarget, wordSize), true);
     }
 
 }

--- a/runtime/src/test/java/org/capnproto/SegmentReaderTest.java
+++ b/runtime/src/test/java/org/capnproto/SegmentReaderTest.java
@@ -15,21 +15,21 @@ public class SegmentReaderTest {
     public void in_boundsCalculationShouldNotOverflow() {
         ByteBuffer byteBuffer = ByteBuffer.allocate(64);
         SegmentReader segmentReader = new SegmentReader(byteBuffer, null);
-        assertEquals(segmentReader.isInBounds(0, Integer.MAX_VALUE), false);
+        assertEquals(false, segmentReader.isInBounds(0, Integer.MAX_VALUE));
     }
 
     @Test
     public void oneWordAtLastWordShouldBeInBounds() {
         ByteBuffer byteBuffer = ByteBuffer.allocate(64);
         SegmentReader segmentReader = new SegmentReader(byteBuffer, null);
-        assertEquals(segmentReader.isInBounds(7, 1), true);
+        assertEquals(true, segmentReader.isInBounds(7, 1));
     }
 
     @Test
     public void twoWordsAtLastWordShouldNotBeInBounds() {
         ByteBuffer byteBuffer = ByteBuffer.allocate(64);
         SegmentReader segmentReader = new SegmentReader(byteBuffer, null);
-        assertEquals(segmentReader.isInBounds(7, 2), false);
+        assertEquals(false, segmentReader.isInBounds(7, 2));
     }
 
     @Test
@@ -78,7 +78,7 @@ public class SegmentReaderTest {
         refTarget = WirePointer.target(refOffset, ref);
         dataSizeWords = StructPointer.dataSize(ref);
         wordSize = dataSizeWords + StructPointer.ptrCount(ref);
-        assertEquals(segment.isInBounds(refTarget, wordSize), true);
+        assertEquals(true, segment.isInBounds(refTarget, wordSize));
 
         /* Read inner Struct: ComObject. */
         refOffset = refTarget + dataSizeWords; /* At the inner STRUCT POINTER */
@@ -86,7 +86,7 @@ public class SegmentReaderTest {
         refTarget = WirePointer.target(refOffset, ref);
         dataSizeWords = StructPointer.dataSize(ref);
         wordSize = dataSizeWords + StructPointer.ptrCount(ref);
-        assertEquals(segment.isInBounds(refTarget, wordSize), true);
+        assertEquals(true, segment.isInBounds(refTarget, wordSize));
     }
 
 }

--- a/runtime/src/test/java/org/capnproto/SerializePackedTest.java
+++ b/runtime/src/test/java/org/capnproto/SerializePackedTest.java
@@ -9,6 +9,11 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 public class SerializePackedTest {
 
     @Test
@@ -63,10 +68,10 @@ public class SerializePackedTest {
             try {
                 packedOutputStream.write(ByteBuffer.wrap(unpacked));
             } catch (IOException e) {
-                Assertions.fail("Failed writing to PackedOutputStream");
+                fail("Failed writing to PackedOutputStream");
             }
 
-            Assertions.assertTrue(Arrays.equals(bytes, packed));
+            assertTrue(Arrays.equals(bytes, packed));
         }
 
         {
@@ -77,11 +82,11 @@ public class SerializePackedTest {
             try {
                 n = stream.read(ByteBuffer.wrap(bytes));
             } catch (IOException e) {
-                Assertions.fail("Failed reading from PackedInputStream");
+                fail("Failed reading from PackedInputStream");
             }
 
-            Assertions.assertEquals(n, unpacked.length);
-            Assertions.assertTrue(Arrays.equals(bytes, unpacked));
+            assertEquals(n, unpacked.length);
+            assertTrue(Arrays.equals(bytes, unpacked));
         }
     }
 
@@ -89,13 +94,13 @@ public class SerializePackedTest {
     @Timeout(value = 1000, unit = TimeUnit.MILLISECONDS)
     public void read_shouldThrowDecodingExceptionOnEmptyArrayInputStream() throws IOException {
         byte[] emptyByteArray = {};
-        Assertions.assertThrows(DecodeException.class, () -> SerializePacked.read(new ArrayInputStream(ByteBuffer.wrap(emptyByteArray)), ReaderOptions.DEFAULT_READER_OPTIONS));
+        assertThrows(DecodeException.class, () -> SerializePacked.read(new ArrayInputStream(ByteBuffer.wrap(emptyByteArray)), ReaderOptions.DEFAULT_READER_OPTIONS));
     }
 
     @Test
     @Timeout(value = 1000, unit = TimeUnit.MILLISECONDS)
     public void read_shouldThrowDecodingExceptionWhenTryingToReadMoreThanAvailableFromArrayInputStream() throws IOException {
         byte[] bytes = {17, 0, 127, 0, 0, 0, 0}; //segment0 size of 127 words, which is way larger than the tiny 7 byte input
-        Assertions.assertThrows(DecodeException.class, () -> SerializePacked.read(new ArrayInputStream(ByteBuffer.wrap(bytes)), ReaderOptions.DEFAULT_READER_OPTIONS));
+        assertThrows(DecodeException.class, () -> SerializePacked.read(new ArrayInputStream(ByteBuffer.wrap(bytes)), ReaderOptions.DEFAULT_READER_OPTIONS));
     }
 }

--- a/runtime/src/test/java/org/capnproto/SerializePackedTest.java
+++ b/runtime/src/test/java/org/capnproto/SerializePackedTest.java
@@ -1,11 +1,13 @@
 package org.capnproto;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 public class SerializePackedTest {
 
@@ -61,10 +63,10 @@ public class SerializePackedTest {
             try {
                 packedOutputStream.write(ByteBuffer.wrap(unpacked));
             } catch (IOException e) {
-                Assert.fail("Failed writing to PackedOutputStream");
+                Assertions.fail("Failed writing to PackedOutputStream");
             }
 
-            Assert.assertTrue(Arrays.equals(bytes, packed));
+            Assertions.assertTrue(Arrays.equals(bytes, packed));
         }
 
         {
@@ -75,23 +77,25 @@ public class SerializePackedTest {
             try {
                 n = stream.read(ByteBuffer.wrap(bytes));
             } catch (IOException e) {
-                Assert.fail("Failed reading from PackedInputStream");
+                Assertions.fail("Failed reading from PackedInputStream");
             }
 
-            Assert.assertEquals(n, unpacked.length);
-            Assert.assertTrue(Arrays.equals(bytes, unpacked));
+            Assertions.assertEquals(n, unpacked.length);
+            Assertions.assertTrue(Arrays.equals(bytes, unpacked));
         }
     }
 
-    @Test(timeout = 1000, expected = DecodeException.class)
+    @Test
+    @Timeout(value = 1000, unit = TimeUnit.MILLISECONDS)
     public void read_shouldThrowDecodingExceptionOnEmptyArrayInputStream() throws IOException {
         byte[] emptyByteArray = {};
-        MessageReader reader = SerializePacked.read(new ArrayInputStream(ByteBuffer.wrap(emptyByteArray)), ReaderOptions.DEFAULT_READER_OPTIONS);
+        Assertions.assertThrows(DecodeException.class, () -> SerializePacked.read(new ArrayInputStream(ByteBuffer.wrap(emptyByteArray)), ReaderOptions.DEFAULT_READER_OPTIONS));
     }
 
-    @Test(timeout = 1000, expected = DecodeException.class)
+    @Test
+    @Timeout(value = 1000, unit = TimeUnit.MILLISECONDS)
     public void read_shouldThrowDecodingExceptionWhenTryingToReadMoreThanAvailableFromArrayInputStream() throws IOException {
         byte[] bytes = {17, 0, 127, 0, 0, 0, 0}; //segment0 size of 127 words, which is way larger than the tiny 7 byte input
-        MessageReader reader = SerializePacked.read(new ArrayInputStream(ByteBuffer.wrap(bytes)), ReaderOptions.DEFAULT_READER_OPTIONS);
+        Assertions.assertThrows(DecodeException.class, () -> SerializePacked.read(new ArrayInputStream(ByteBuffer.wrap(bytes)), ReaderOptions.DEFAULT_READER_OPTIONS));
     }
 }

--- a/runtime/src/test/java/org/capnproto/SerializeTest.java
+++ b/runtime/src/test/java/org/capnproto/SerializeTest.java
@@ -21,17 +21,14 @@
 
 package org.capnproto;
 
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Optional;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SerializeTest {
 
@@ -39,15 +36,15 @@ public class SerializeTest {
    * @param arena: segment `i` contains `i` words each set to `i`
    */
   private void checkSegmentContents(int exampleSegmentCount, ReaderArena arena) {
-    Assert.assertEquals(arena.segments.size(), exampleSegmentCount);
+    Assertions.assertEquals(arena.segments.size(), exampleSegmentCount);
     for (int i = 0; i < exampleSegmentCount; ++i) {
       SegmentReader segment = arena.segments.get(i);
       java.nio.LongBuffer segmentWords = segment.buffer.asLongBuffer();
 
-      Assert.assertEquals(segmentWords.capacity(), i);
+      Assertions.assertEquals(segmentWords.capacity(), i);
       segmentWords.rewind();
       while (segmentWords.hasRemaining()) {
-        Assert.assertEquals(segmentWords.get(), i);
+        Assertions.assertEquals(segmentWords.get(), i);
       }
     }
   }
@@ -65,7 +62,7 @@ public class SerializeTest {
 
       byte[] outputBytes = new byte[exampleBytes.length];
       Serialize.write(new ArrayOutputStream(ByteBuffer.wrap(outputBytes)), messageReader);
-      Assert.assertArrayEquals(exampleBytes, outputBytes);
+      Assertions.assertArrayEquals(exampleBytes, outputBytes);
     }
 
     // ------
@@ -148,13 +145,13 @@ public class SerializeTest {
               // Segment 0 (empty)
       };
       Optional<MessageReader> messageReader = Serialize.tryRead(new ArrayInputStream(ByteBuffer.wrap(input)));
-      Assert.assertTrue(messageReader.isPresent());
+      Assertions.assertTrue(messageReader.isPresent());
     }
 
     // `tryRead` returns null when given no input
     {
       Optional<MessageReader> messageReader = Serialize.tryRead(new ArrayInputStream(ByteBuffer.wrap(new byte[]{})));
-      Assert.assertFalse(messageReader.isPresent());
+      Assertions.assertFalse(messageReader.isPresent());
     }
 
     // `tryRead` throws when given too few bytes to form the first word
@@ -163,34 +160,34 @@ public class SerializeTest {
               0, 0, 0, 0, // 1 segment
               0, 0, 0     // Premature end of stream after 7 bytes
       };
-      Assert.assertThrows(IOException.class, () -> Serialize.tryRead(new ArrayInputStream(ByteBuffer.wrap(input))));
+      Assertions.assertThrows(IOException.class, () -> Serialize.tryRead(new ArrayInputStream(ByteBuffer.wrap(input))));
     }
   }
 
-  @Test(expected=DecodeException.class)
+  @Test
   public void testSegment0SizeOverflow() throws java.io.IOException {
         byte[] input = {0, 0, 0, 0, -1, -1, -1, -113};
         java.nio.channels.ReadableByteChannel channel =
             java.nio.channels.Channels.newChannel(new java.io.ByteArrayInputStream(input));
-        MessageReader message = Serialize.read(channel);
+        Assertions.assertThrows(DecodeException.class, () -> Serialize.read(channel));
   }
 
-  @Test(expected=DecodeException.class)
+  @Test
   public void testSegment1SizeOverflow() throws java.io.IOException {
       byte[] input = {
           1, 0, 0, 0, 1, 0, 0, 0,
           -1, -1, -1, -113, 0, 0, 0, 0};
         java.nio.channels.ReadableByteChannel channel =
             java.nio.channels.Channels.newChannel(new java.io.ByteArrayInputStream(input));
-        MessageReader message = Serialize.read(channel);
+        Assertions.assertThrows(DecodeException.class, () -> Serialize.read(channel));
   }
 
     @Test
-    @Ignore("Ignored by default because the huge array used in the test results in a long execution")
+    @Disabled("Ignored by default because the huge array used in the test results in a long execution")
     public void computeSerializedSizeInWordsShouldNotOverflowOnLargeSegmentCounts() {
         ByteBuffer dummySegmentBuffer = ByteBuffer.allocate(0);
         ByteBuffer[] segments = new ByteBuffer[Integer.MAX_VALUE / 2];
         Arrays.fill(segments, dummySegmentBuffer);
-        assertThat(Serialize.computeSerializedSizeInWords(segments), is((segments.length * 4L + 4) / Constants.BYTES_PER_WORD));
+        Assertions.assertEquals(Serialize.computeSerializedSizeInWords(segments), (segments.length * 4L + 4) / Constants.BYTES_PER_WORD);
     }
 }

--- a/runtime/src/test/java/org/capnproto/SerializeTest.java
+++ b/runtime/src/test/java/org/capnproto/SerializeTest.java
@@ -30,21 +30,27 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class SerializeTest {
 
   /**
    * @param arena: segment `i` contains `i` words each set to `i`
    */
   private void checkSegmentContents(int exampleSegmentCount, ReaderArena arena) {
-    Assertions.assertEquals(arena.segments.size(), exampleSegmentCount);
+    assertEquals(arena.segments.size(), exampleSegmentCount);
     for (int i = 0; i < exampleSegmentCount; ++i) {
       SegmentReader segment = arena.segments.get(i);
       java.nio.LongBuffer segmentWords = segment.buffer.asLongBuffer();
 
-      Assertions.assertEquals(segmentWords.capacity(), i);
+      assertEquals(segmentWords.capacity(), i);
       segmentWords.rewind();
       while (segmentWords.hasRemaining()) {
-        Assertions.assertEquals(segmentWords.get(), i);
+        assertEquals(segmentWords.get(), i);
       }
     }
   }
@@ -62,7 +68,7 @@ public class SerializeTest {
 
       byte[] outputBytes = new byte[exampleBytes.length];
       Serialize.write(new ArrayOutputStream(ByteBuffer.wrap(outputBytes)), messageReader);
-      Assertions.assertArrayEquals(exampleBytes, outputBytes);
+      assertArrayEquals(exampleBytes, outputBytes);
     }
 
     // ------
@@ -145,13 +151,13 @@ public class SerializeTest {
               // Segment 0 (empty)
       };
       Optional<MessageReader> messageReader = Serialize.tryRead(new ArrayInputStream(ByteBuffer.wrap(input)));
-      Assertions.assertTrue(messageReader.isPresent());
+      assertTrue(messageReader.isPresent());
     }
 
     // `tryRead` returns null when given no input
     {
       Optional<MessageReader> messageReader = Serialize.tryRead(new ArrayInputStream(ByteBuffer.wrap(new byte[]{})));
-      Assertions.assertFalse(messageReader.isPresent());
+      assertFalse(messageReader.isPresent());
     }
 
     // `tryRead` throws when given too few bytes to form the first word
@@ -160,7 +166,7 @@ public class SerializeTest {
               0, 0, 0, 0, // 1 segment
               0, 0, 0     // Premature end of stream after 7 bytes
       };
-      Assertions.assertThrows(IOException.class, () -> Serialize.tryRead(new ArrayInputStream(ByteBuffer.wrap(input))));
+      assertThrows(IOException.class, () -> Serialize.tryRead(new ArrayInputStream(ByteBuffer.wrap(input))));
     }
   }
 
@@ -169,7 +175,7 @@ public class SerializeTest {
         byte[] input = {0, 0, 0, 0, -1, -1, -1, -113};
         java.nio.channels.ReadableByteChannel channel =
             java.nio.channels.Channels.newChannel(new java.io.ByteArrayInputStream(input));
-        Assertions.assertThrows(DecodeException.class, () -> Serialize.read(channel));
+        assertThrows(DecodeException.class, () -> Serialize.read(channel));
   }
 
   @Test
@@ -179,7 +185,7 @@ public class SerializeTest {
           -1, -1, -1, -113, 0, 0, 0, 0};
         java.nio.channels.ReadableByteChannel channel =
             java.nio.channels.Channels.newChannel(new java.io.ByteArrayInputStream(input));
-        Assertions.assertThrows(DecodeException.class, () -> Serialize.read(channel));
+        assertThrows(DecodeException.class, () -> Serialize.read(channel));
   }
 
     @Test
@@ -188,6 +194,6 @@ public class SerializeTest {
         ByteBuffer dummySegmentBuffer = ByteBuffer.allocate(0);
         ByteBuffer[] segments = new ByteBuffer[Integer.MAX_VALUE / 2];
         Arrays.fill(segments, dummySegmentBuffer);
-        Assertions.assertEquals(Serialize.computeSerializedSizeInWords(segments), (segments.length * 4L + 4) / Constants.BYTES_PER_WORD);
+        assertEquals(Serialize.computeSerializedSizeInWords(segments), (segments.length * 4L + 4) / Constants.BYTES_PER_WORD);
     }
 }

--- a/runtime/src/test/java/org/capnproto/StructPointerTest.java
+++ b/runtime/src/test/java/org/capnproto/StructPointerTest.java
@@ -3,45 +3,47 @@ package org.capnproto;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class StructPointerTest {
     @Test
     public void testDataSize() {
-        Assertions.assertEquals(
+        assertEquals(
             2,
             StructPointer.dataSize(0x0001000200000000L));
     }
 
     @Test
     public void testDataSizeUnderflow() {
-        Assertions.assertEquals(
+        assertEquals(
             0xffff,
             StructPointer.dataSize(0x0001ffff00000000L));
     }
 
     @Test
     public void testPtrCount() {
-        Assertions.assertEquals(
+        assertEquals(
             1,
             StructPointer.ptrCount(0x0001000200000000L));
     }
 
     @Test
     public void testPtrCountUnderflow() {
-        Assertions.assertEquals(
+        assertEquals(
             0xffff,
             StructPointer.ptrCount(0xffff000200000000L));
     }
 
     @Test
     public void testWordSize() {
-        Assertions.assertEquals(
+        assertEquals(
             3,
             StructPointer.wordSize(0x0001000200000000L));
     }
 
     @Test
     public void testWordSizeUnderflow() {
-        Assertions.assertEquals(
+        assertEquals(
             0x1fffe,
             StructPointer.wordSize(0xffffffff00000000L));
     }

--- a/runtime/src/test/java/org/capnproto/StructPointerTest.java
+++ b/runtime/src/test/java/org/capnproto/StructPointerTest.java
@@ -1,47 +1,47 @@
 package org.capnproto;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class StructPointerTest {
     @Test
     public void testDataSize() {
-        Assert.assertEquals(
+        Assertions.assertEquals(
             2,
             StructPointer.dataSize(0x0001000200000000L));
     }
 
     @Test
     public void testDataSizeUnderflow() {
-        Assert.assertEquals(
+        Assertions.assertEquals(
             0xffff,
             StructPointer.dataSize(0x0001ffff00000000L));
     }
 
     @Test
     public void testPtrCount() {
-        Assert.assertEquals(
+        Assertions.assertEquals(
             1,
             StructPointer.ptrCount(0x0001000200000000L));
     }
 
     @Test
     public void testPtrCountUnderflow() {
-        Assert.assertEquals(
+        Assertions.assertEquals(
             0xffff,
             StructPointer.ptrCount(0xffff000200000000L));
     }
 
     @Test
     public void testWordSize() {
-        Assert.assertEquals(
+        Assertions.assertEquals(
             3,
             StructPointer.wordSize(0x0001000200000000L));
     }
 
     @Test
     public void testWordSizeUnderflow() {
-        Assert.assertEquals(
+        Assertions.assertEquals(
             0x1fffe,
             StructPointer.wordSize(0xffffffff00000000L));
     }


### PR DESCRIPTION
- Bumps JUnit `4.13.1` -> `5.11.4`.
- Updates code accordingly.