### PR TITLE
fix: transferPointer far pointer creation

### DIFF
--- a/runtime/src/main/java/org/capnproto/WireHelpers.java
+++ b/runtime/src/main/java/org/capnproto/WireHelpers.java
@@ -340,7 +340,6 @@ final class WireHelpers {
         //# OrphanBuilder.
 
         long src = srcSegment.get(srcOffset);
-        long srcTarget = srcSegment.get(srcTargetOffset);
 
         if (dstSegment == srcSegment) {
             //# Same segment, so create a direct pointer.
@@ -383,7 +382,7 @@ final class WireHelpers {
             } else {
                 //# Simple landing pad is just a pointer.
                 WirePointer.setKindAndTarget(srcSegment.buffer, landingPadOffset,
-                                             WirePointer.kind(srcTarget), srcTargetOffset);
+                                             WirePointer.kind(src), srcTargetOffset);
                 srcSegment.buffer.putInt(landingPadOffset * Constants.BYTES_PER_WORD + 4,
                                          srcSegment.buffer.getInt(srcOffset * Constants.BYTES_PER_WORD + 4));
 


### PR DESCRIPTION
A previous commit (14237610fb62622d34731c9fbd7fce25ad46496d) fixed this bug in double-far pointer creation; this commit fixes it in single far pointer creation.